### PR TITLE
Use ApplicationData by Default instead of AMQPValue for the message creation

### DIFF
--- a/.ci/ubuntu/cluster/gha-setup.sh
+++ b/.ci/ubuntu/cluster/gha-setup.sh
@@ -19,7 +19,7 @@ function run_docker_compose
     docker compose --file "$script_dir/docker-compose.yml" $@
 }
 
-readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.1.0-beta.4-management-alpine}"
+readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.1.0-management-alpine}"
 
 if [[ ! -v GITHUB_ACTIONS ]]
 then

--- a/.ci/ubuntu/one-node/gha-setup.sh
+++ b/.ci/ubuntu/one-node/gha-setup.sh
@@ -9,7 +9,7 @@ readonly script_dir
 echo "[INFO] script_dir: '$script_dir'"
 
 
-readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.1.0-beta.4-management-alpine}"
+readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.1.0-management-alpine}"
 
 
 

--- a/.ci/windows/versions.json
+++ b/.ci/windows/versions.json
@@ -1,4 +1,4 @@
 {
   "erlang": "27.2",
-  "rabbitmq": "4.1.0-beta.4"
+  "rabbitmq": "4.1.0"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -129,4 +129,5 @@ docs/temp/
 
 # ci logs
 .ci/ubuntu/log/*
+.ci/ubuntu/cluster/log/*
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,6 +7,7 @@
     <PackageVersion Include="AMQPNetLite.Core" Version="2.4.11" />
     <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
+    <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
     <!-- HAClient -->
     <PackageVersion Include="DotNext.Threading" Version="5.15.0" />

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -7,7 +7,7 @@
     <PackageVersion Include="AMQPNetLite.Core" Version="2.4.11" />
     <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />
-    <PackageVersion Include="RabbitMQ.Client" Version="7.1.2" />
+    <PackageVersion Include="RabbitMQ.Client" Version="6.8.1" />
     <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="9.0.0" />
     <!-- HAClient -->
     <PackageVersion Include="DotNext.Threading" Version="5.15.0" />

--- a/RabbitMQ.AMQP.Client/IMessage.cs
+++ b/RabbitMQ.AMQP.Client/IMessage.cs
@@ -97,10 +97,9 @@ namespace RabbitMQ.AMQP.Client
         public IMessage Annotation(string key, object value);
 
         public byte[] Body();
-        
+
         public string BodyAsString();
-        
-        
+
         public IMessage Body(object body);
 
         IMessageAddressBuilder ToAddress();

--- a/RabbitMQ.AMQP.Client/IMessage.cs
+++ b/RabbitMQ.AMQP.Client/IMessage.cs
@@ -96,7 +96,11 @@ namespace RabbitMQ.AMQP.Client
         public object Annotation(string key);
         public IMessage Annotation(string key, object value);
 
-        public object Body();
+        public byte[] Body();
+        
+        public string BodyAsString();
+        
+        
         public IMessage Body(object body);
 
         IMessageAddressBuilder ToAddress();

--- a/RabbitMQ.AMQP.Client/IRpcServer.cs
+++ b/RabbitMQ.AMQP.Client/IRpcServer.cs
@@ -78,7 +78,8 @@ namespace RabbitMQ.AMQP.Client
 
         public interface IContext
         {
-            IMessage Message(object body);
+            IMessage Message(byte[] body);
+            IMessage Message(string body);
         }
     }
 }

--- a/RabbitMQ.AMQP.Client/Impl/AmqpMessage.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpMessage.cs
@@ -269,7 +269,7 @@ namespace RabbitMQ.AMQP.Client.Impl
             {
                 throw new InvalidOperationException("Body is not an Application Data");
             }
-            
+
         }
 
         public IMessage Body(object body)

--- a/RabbitMQ.AMQP.Client/Impl/AmqpMessage.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpMessage.cs
@@ -24,14 +24,20 @@ namespace RabbitMQ.AMQP.Client.Impl
             NativeMessage = new Message();
         }
 
+        /// <summary>
+        /// Create a message with a body of type byte[] and BodySection of type Data.
+        /// </summary>
+        /// <param name="body"></param>
         public AmqpMessage(byte[] body)
         {
             NativeMessage = new Message();
             NativeMessage.BodySection = new Data { Binary = body };
         }
 
-        // This constructor is used for string body
-        // Like AmqpMessage(byte[] body) but for string with UTF8 encoding
+        /// <summary>
+        /// Create a message with a body of type string and BodySection of type Data.
+        /// The string is converted to a byte[] using UTF8 encoding.
+        /// </summary>
         public AmqpMessage(string body)
         {
             NativeMessage = new Message();

--- a/RabbitMQ.AMQP.Client/Impl/AmqpRpcServer.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpRpcServer.cs
@@ -166,7 +166,8 @@ namespace RabbitMQ.AMQP.Client.Impl
 
         private class RpcServerContext : IRpcServer.IContext
         {
-            public IMessage Message(object body) => new AmqpMessage(body);
+            public IMessage Message(byte[] body) => new AmqpMessage(body);
+            public IMessage Message(string body) => new AmqpMessage(body);
         }
 
         public override async Task CloseAsync()

--- a/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
@@ -245,8 +245,9 @@ RabbitMQ.AMQP.Client.IMessage.AbsoluteExpiryTime() -> System.DateTime
 RabbitMQ.AMQP.Client.IMessage.AbsoluteExpiryTime(System.DateTime absoluteExpiryTime) -> RabbitMQ.AMQP.Client.IMessage!
 RabbitMQ.AMQP.Client.IMessage.Annotation(string! key) -> object!
 RabbitMQ.AMQP.Client.IMessage.Annotation(string! key, object! value) -> RabbitMQ.AMQP.Client.IMessage!
-RabbitMQ.AMQP.Client.IMessage.Body() -> object!
+RabbitMQ.AMQP.Client.IMessage.Body() -> byte[]!
 RabbitMQ.AMQP.Client.IMessage.Body(object! body) -> RabbitMQ.AMQP.Client.IMessage!
+RabbitMQ.AMQP.Client.IMessage.BodyAsString() -> string!
 RabbitMQ.AMQP.Client.IMessage.ContentEncoding() -> string!
 RabbitMQ.AMQP.Client.IMessage.ContentEncoding(string! contentEncoding) -> RabbitMQ.AMQP.Client.IMessage!
 RabbitMQ.AMQP.Client.IMessage.ContentType() -> string!
@@ -391,11 +392,13 @@ RabbitMQ.AMQP.Client.Impl.AmqpMessage.AbsoluteExpiryTime() -> System.DateTime
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.AbsoluteExpiryTime(System.DateTime absoluteExpiryTime) -> RabbitMQ.AMQP.Client.IMessage!
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.AmqpMessage() -> void
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.AmqpMessage(Amqp.Message! nativeMessage) -> void
-RabbitMQ.AMQP.Client.Impl.AmqpMessage.AmqpMessage(object! body) -> void
+RabbitMQ.AMQP.Client.Impl.AmqpMessage.AmqpMessage(byte[]! body) -> void
+RabbitMQ.AMQP.Client.Impl.AmqpMessage.AmqpMessage(string! body) -> void
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.Annotation(string! key) -> object!
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.Annotation(string! key, object! value) -> RabbitMQ.AMQP.Client.IMessage!
-RabbitMQ.AMQP.Client.Impl.AmqpMessage.Body() -> object!
+RabbitMQ.AMQP.Client.Impl.AmqpMessage.Body() -> byte[]!
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.Body(object! body) -> RabbitMQ.AMQP.Client.IMessage!
+RabbitMQ.AMQP.Client.Impl.AmqpMessage.BodyAsString() -> string!
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.ContentEncoding() -> string!
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.ContentEncoding(string! contentEncoding) -> RabbitMQ.AMQP.Client.IMessage!
 RabbitMQ.AMQP.Client.Impl.AmqpMessage.ContentType() -> string!
@@ -674,7 +677,8 @@ RabbitMQ.AMQP.Client.IRpcClientBuilder.RequestPostProcessor(System.Func<RabbitMQ
 RabbitMQ.AMQP.Client.IRpcClientBuilder.Timeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IRpcClientBuilder!
 RabbitMQ.AMQP.Client.IRpcServer
 RabbitMQ.AMQP.Client.IRpcServer.IContext
-RabbitMQ.AMQP.Client.IRpcServer.IContext.Message(object! body) -> RabbitMQ.AMQP.Client.IMessage!
+RabbitMQ.AMQP.Client.IRpcServer.IContext.Message(byte[]! body) -> RabbitMQ.AMQP.Client.IMessage!
+RabbitMQ.AMQP.Client.IRpcServer.IContext.Message(string! body) -> RabbitMQ.AMQP.Client.IMessage!
 RabbitMQ.AMQP.Client.IRpcServerBuilder
 RabbitMQ.AMQP.Client.IRpcServerBuilder.BuildAsync() -> System.Threading.Tasks.Task<RabbitMQ.AMQP.Client.IRpcServer!>!
 RabbitMQ.AMQP.Client.IRpcServerBuilder.CorrelationIdExtractor(System.Func<RabbitMQ.AMQP.Client.IMessage!, object!>? correlationIdExtractor) -> RabbitMQ.AMQP.Client.IRpcServerBuilder!

--- a/Tests/Amqp091/FromToAmqp091Tests.cs
+++ b/Tests/Amqp091/FromToAmqp091Tests.cs
@@ -2,11 +2,7 @@
 // and the Mozilla Public License, version 2.0.
 // Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
-using System;
-using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
 using RabbitMQ.AMQP.Client;
 using RabbitMQ.AMQP.Client.Impl;
 using RabbitMQ.Client;

--- a/Tests/Amqp091/FromToAmqp091Tests.cs
+++ b/Tests/Amqp091/FromToAmqp091Tests.cs
@@ -26,7 +26,7 @@ namespace Tests.Amqp091
             var publisher = await _connection.PublisherBuilder().BuildAsync();
             const string body = "{Text:as,Seq:1,Max:7000}";
             IMessage amqpMessage = new AmqpMessage(body).ToAddress().Queue(_queueName).Build();
-            for (int i = 0; i < 0; i++)
+            for (int i = 0; i < 1; i++)
             {
                 PublishResult result = await publisher.PublishAsync(message: amqpMessage).ConfigureAwait(true);
                 Assert.NotNull(result);

--- a/Tests/Amqp091/FromToAmqp091Tests.cs
+++ b/Tests/Amqp091/FromToAmqp091Tests.cs
@@ -2,6 +2,7 @@
 // and the Mozilla Public License, version 2.0.
 // Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
+using System;
 using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
@@ -28,34 +29,14 @@ namespace Tests.Amqp091
             await queueSpec.DeclareAsync();
 
             var publisher = await _connection.PublisherBuilder().BuildAsync();
-            // string text = JsonConvert.SerializeObject(message); //produces {"Text":"as","Seq":1,"Max":7000} 
             byte[] body = System.Text.Encoding.UTF8.GetBytes("{Text:as,Seq:1,Max:7000}");
             IMessage amqpMessage = new AmqpMessage(body).ToAddress().Queue(_queueName).Build();
-            for (int i = 0; i < 100; i++)
+            for (int i = 0; i < 1; i++)
             {
                 PublishResult result = await publisher.PublishAsync(message: amqpMessage).ConfigureAwait(true);
                 Assert.NotNull(result);
                 Assert.Equal(OutcomeState.Accepted, result.Outcome.State);
             }
-
-
-            // TaskCompletionSource<IMessage> tcs = new();
-            // IConsumer consumer = await _connection.ConsumerBuilder()
-            //     .Queue(queueSpec)
-            //     .MessageHandler((context, message) =>
-            //         {
-            //             tcs.SetResult(message);
-            //             context.Accept();
-            //             return Task.CompletedTask;
-            //         }
-            //     ).BuildAndStartAsync();
-            //
-            // IMessage receivedMessage = await tcs.Task;
-            // Assert.NotNull(receivedMessage);
-            // // get the string form bytes
-            //
-            // string receivedMessageBody = System.Text.Encoding.UTF8.GetString((byte[])receivedMessage.Body());
-            // Assert.Equal("{Text:as,Seq:1,Max:7000}", receivedMessageBody);
 
 
             var factory = new ConnectionFactory();

--- a/Tests/Amqp091/FromToAmqp091Tests.cs
+++ b/Tests/Amqp091/FromToAmqp091Tests.cs
@@ -1,0 +1,80 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Newtonsoft.Json;
+using RabbitMQ.AMQP.Client;
+using RabbitMQ.AMQP.Client.Impl;
+using RabbitMQ.Client;
+using RabbitMQ.Client.Events;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests.Amqp091
+{
+    public class FromToAmqp091Tests(ITestOutputHelper testOutputHelper) : IntegrationTest(testOutputHelper)
+    {
+        [Fact]
+        public async Task ToAmqp091()
+        {
+            Assert.NotNull(_connection);
+            Assert.NotNull(_management);
+            _queueName = "q";
+
+            IQueueSpecification queueSpec = _management.Queue().Name(_queueName).Type(QueueType.QUORUM);
+            await queueSpec.DeclareAsync();
+
+            var publisher = await _connection.PublisherBuilder().BuildAsync();
+            // string text = JsonConvert.SerializeObject(message); //produces {"Text":"as","Seq":1,"Max":7000} 
+            byte[] body = System.Text.Encoding.UTF8.GetBytes("{Text:as,Seq:1,Max:7000}");
+            IMessage amqpMessage = new AmqpMessage(body).ToAddress().Queue(_queueName).Build();
+            for (int i = 0; i < 100; i++)
+            {
+                PublishResult result = await publisher.PublishAsync(message: amqpMessage).ConfigureAwait(true);
+                Assert.NotNull(result);
+                Assert.Equal(OutcomeState.Accepted, result.Outcome.State);
+            }
+
+
+            // TaskCompletionSource<IMessage> tcs = new();
+            // IConsumer consumer = await _connection.ConsumerBuilder()
+            //     .Queue(queueSpec)
+            //     .MessageHandler((context, message) =>
+            //         {
+            //             tcs.SetResult(message);
+            //             context.Accept();
+            //             return Task.CompletedTask;
+            //         }
+            //     ).BuildAndStartAsync();
+            //
+            // IMessage receivedMessage = await tcs.Task;
+            // Assert.NotNull(receivedMessage);
+            // // get the string form bytes
+            //
+            // string receivedMessageBody = System.Text.Encoding.UTF8.GetString((byte[])receivedMessage.Body());
+            // Assert.Equal("{Text:as,Seq:1,Max:7000}", receivedMessageBody);
+
+
+            var factory = new ConnectionFactory();
+            var connection = await factory.CreateConnectionAsync();
+            var channel = await connection.CreateChannelAsync();
+            var consumer091 = new AsyncEventingBasicConsumer(channel);
+            var tcs091 = new TaskCompletionSource<BasicDeliverEventArgs>();
+            consumer091.ReceivedAsync += async (sender, ea) =>
+            {
+                tcs091.SetResult(ea);
+                await channel.BasicAckAsync(deliveryTag: ea.DeliveryTag, multiple: false);
+            };
+            await channel.BasicConsumeAsync(_queueName, false, "consumerTag", consumer091);
+            var receivedMessage091 = await tcs091.Task;
+            Assert.NotNull(receivedMessage091);
+            Assert.Equal(_queueName, receivedMessage091.RoutingKey);
+            Assert.Equal("consumerTag", receivedMessage091.ConsumerTag);
+            Assert.Equal("{Text:as,Seq:1,Max:7000}",
+                System.Text.Encoding.UTF8.GetString(receivedMessage091.Body.ToArray()));
+        }
+    }
+}

--- a/Tests/Amqp091/FromToAmqp091Tests.cs
+++ b/Tests/Amqp091/FromToAmqp091Tests.cs
@@ -38,7 +38,6 @@ namespace Tests.Amqp091
                 Assert.Equal(OutcomeState.Accepted, result.Outcome.State);
             }
 
-
             var factory = new ConnectionFactory();
             var connection = await factory.CreateConnectionAsync();
             var channel = await connection.CreateChannelAsync();

--- a/Tests/Amqp091/FromToAmqp091Tests.cs
+++ b/Tests/Amqp091/FromToAmqp091Tests.cs
@@ -39,16 +39,16 @@ namespace Tests.Amqp091
             }
 
             var factory = new ConnectionFactory();
-            var connection = await factory.CreateConnectionAsync();
-            var channel = await connection.CreateChannelAsync();
-            var consumer091 = new AsyncEventingBasicConsumer(channel);
+            var connection = factory.CreateConnection();
+            var channel = connection.CreateModel();
+            var consumer091 = new EventingBasicConsumer(channel);
             var tcs091 = new TaskCompletionSource<BasicDeliverEventArgs>();
-            consumer091.ReceivedAsync += async (sender, ea) =>
+            consumer091.Received += (sender, ea) =>
             {
                 tcs091.SetResult(ea);
-                await channel.BasicAckAsync(deliveryTag: ea.DeliveryTag, multiple: false);
+                channel.BasicAck(deliveryTag: ea.DeliveryTag, multiple: false);
             };
-            await channel.BasicConsumeAsync(_queueName, false, "consumerTag", consumer091);
+            channel.BasicConsume(_queueName, false, "consumerTag", consumer091);
             var receivedMessage091 = await tcs091.Task;
             Assert.NotNull(receivedMessage091);
             Assert.Equal(_queueName, receivedMessage091.RoutingKey);

--- a/Tests/Consumer/BasicConsumerTests.cs
+++ b/Tests/Consumer/BasicConsumerTests.cs
@@ -38,7 +38,7 @@ public class BasicConsumerTests(ITestOutputHelper testOutputHelper) : Integratio
 
         await WhenTcsCompletes(tcs);
         IMessage receivedMessage = await tcs.Task;
-        Assert.Equal("message_0", receivedMessage.Body());
+        Assert.Equal("message_0", receivedMessage.BodyAsString());
 
         await consumer.CloseAsync();
         consumer.Dispose();
@@ -69,7 +69,7 @@ public class BasicConsumerTests(ITestOutputHelper testOutputHelper) : Integratio
             {
                 try
                 {
-                    Assert.Equal("message_0", message.Body());
+                    Assert.Equal("message_0", message.BodyAsString());
                     Interlocked.Increment(ref consumed);
                     switch (consumed)
                     {
@@ -167,7 +167,7 @@ public class BasicConsumerTests(ITestOutputHelper testOutputHelper) : Integratio
             {
                 if (i % 2 == 0)
                 {
-                    Assert.Equal($"message_{i}", receivedMessagesFromTask[i].Body());
+                    Assert.Equal($"message_{i}", receivedMessagesFromTask[i].BodyAsString());
                 }
             }
         }

--- a/Tests/MessagesTests.cs
+++ b/Tests/MessagesTests.cs
@@ -22,7 +22,7 @@ public class MessagesTests
         Assert.Equal("CorrelationId_2123", message.CorrelationId());
         Assert.Equal("ReplyTo_5123", message.ReplyTo());
         Assert.Equal("Subject_9123", message.Subject());
-        Assert.Equal("my_body", message.Body());
+        Assert.Equal("my_body", message.BodyAsString());
     }
 
     [Fact]

--- a/Tests/Rpc/RecoveryRPCTests.cs
+++ b/Tests/Rpc/RecoveryRPCTests.cs
@@ -67,7 +67,7 @@ namespace Tests.Rpc
                 {
                     IMessage response = await rpcClient.PublishAsync(request);
                     messagesConfirmed++;
-                    Assert.Equal("pong", response.Body());
+                    Assert.Equal("pong", response.BodyAsString());
                 }
                 catch (AmqpNotOpenException)
                 {

--- a/Tests/Rpc/RpcServerTests.cs
+++ b/Tests/Rpc/RpcServerTests.cs
@@ -57,7 +57,7 @@ namespace Tests.Rpc
 
             await p.PublishAsync(new AmqpMessage("test"));
             IMessage m = await WhenTcsCompletes(tcs);
-            Assert.Equal("pong", m.Body());
+            Assert.Equal("pong", m.BodyAsString());
             await rpcServer.CloseAsync();
         }
 
@@ -143,7 +143,7 @@ namespace Tests.Rpc
             Assert.Equal(OutcomeState.Accepted, pr.Outcome.State);
 
             IMessage m = await WhenTcsCompletes(tcs);
-            Assert.Equal("pong", m.Body());
+            Assert.Equal("pong", m.BodyAsString());
 
             await rpcServer.CloseAsync();
             await consumer.CloseAsync();
@@ -173,7 +173,7 @@ namespace Tests.Rpc
             IMessage message = new AmqpMessage("ping");
 
             IMessage response = await rpcClient.PublishAsync(message);
-            Assert.Equal("pong", response.Body());
+            Assert.Equal("pong", response.BodyAsString());
             await rpcClient.CloseAsync();
             await rpcServer.CloseAsync();
         }
@@ -209,7 +209,7 @@ namespace Tests.Rpc
             IMessage message = new AmqpMessage("ping");
 
             IMessage response = await rpcClient.PublishAsync(message);
-            Assert.Equal("pong", response.Body());
+            Assert.Equal("pong", response.BodyAsString());
             Assert.Equal(_correlationId, response.CorrelationId());
             await rpcClient.CloseAsync();
             await rpcServer.CloseAsync();
@@ -265,7 +265,7 @@ namespace Tests.Rpc
             while (i < 30)
             {
                 IMessage response = await rpcClient.PublishAsync(message);
-                Assert.Equal("pong", response.Body());
+                Assert.Equal("pong", response.BodyAsString());
                 // the server replies with the correlation id in the application properties
                 Assert.Equal($"{_correlationId}_{i}", response.Property("correlationId"));
                 Assert.Equal($"{_correlationId}_{i}", response.Properties()["correlationId"]);
@@ -324,7 +324,7 @@ namespace Tests.Rpc
                 {
                     IMessage message = new AmqpMessage("ping").Property("id", i1);
                     IMessage response = await rpcClient.PublishAsync(message);
-                    Assert.Equal("pong", response.Body());
+                    Assert.Equal("pong", response.BodyAsString());
                 }));
             }
 
@@ -376,7 +376,7 @@ namespace Tests.Rpc
 
             IMessage msg = new AmqpMessage("ping").Property("wait", 1);
             IMessage reply = await rpcClient.PublishAsync(msg);
-            Assert.Equal("pong", reply.Body());
+            Assert.Equal("pong", reply.BodyAsString());
 
             await Assert.ThrowsAsync<TimeoutException>(() => rpcClient.PublishAsync(
                 new AmqpMessage("ping").Property("wait", 700)));

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -29,6 +29,7 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.Testing" />
     <PackageReference Include="Microsoft.Extensions.Diagnostics" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="RabbitMQ.Client" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" />
     <PackageReference Include="System.Text.Json" />
     <PackageReference Include="xunit" />


### PR DESCRIPTION
- Update RabbitMQ to 4.1 for windows and Linux
- **Breaking change**  Change the default section body for message creation. It uses ApplicationData (`0x75`) instead of AmqpValue (`0x77`) 
  Per conversation with @ansd it is better to use ApplicationData for cross-protocol applications. 
 - Add tests with AMQP 091 
 - Fixes #115 