### PR TITLE
Fix multi-tread creation session

### DIFF
--- a/RabbitMQ.AMQP.Client/Impl/AmqpSessionManagement.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpSessionManagement.cs
@@ -78,6 +78,20 @@ namespace RabbitMQ.AMQP.Client.Impl
             }
         }
 
+        // sessions count 
+        internal int GetSessionsCount()
+        {
+            _semaphoreSlim.Wait();
+            try
+            {
+                return _sessions.Count;
+            }
+            finally
+            {
+                _semaphoreSlim.Release();
+            }
+        }
+
         // Note: these values come from Amqp.NET
         static Begin GetDefaultBegin()
         {

--- a/Tests/Sessions/SessionsTests.cs
+++ b/Tests/Sessions/SessionsTests.cs
@@ -1,0 +1,55 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using RabbitMQ.AMQP.Client.Impl;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests.Sessions
+{
+    public class SessionsTests(ITestOutputHelper testOutputHelper) : IntegrationTest(testOutputHelper)
+    {
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(37)]
+        public async Task CreateSessionSequentiallyShouldHaveTheMaxSessionsPerItem(int maxSessions)
+        {
+            Assert.NotNull(_connection);
+            AmqpConnection? amqpConnection = _connection as AmqpConnection;
+            Assert.NotNull(amqpConnection);
+            AmqpSessionManagement s = new(amqpConnection, maxSessions);
+            for (int i = 0; i < 100; i++)
+            {
+                await s.GetOrCreateSessionAsync();
+            }
+
+            Assert.Equal(maxSessions, s.GetSessionsCount());
+        }
+
+        [Theory]
+        [InlineData(1)]
+        [InlineData(10)]
+        [InlineData(37)]
+        public async Task CreateSessionInMultiThreadingShouldHaveTheMaxSessionsPerItem(int maxSessions)
+        {
+            Assert.NotNull(_connection);
+            AmqpConnection? amqpConnection = _connection as AmqpConnection;
+            Assert.NotNull(amqpConnection);
+            AmqpSessionManagement s = new(amqpConnection, maxSessions);
+            Task[] tasks = new Task[100];
+            for (int i = 0; i < 100; i++)
+            {
+                tasks[i] = (Task.Run(async () => { await s.GetOrCreateSessionAsync(); }));
+            }
+
+            await Task.WhenAll(tasks);
+
+            Assert.Equal(maxSessions, s.GetSessionsCount());
+        }
+    }
+}


### PR DESCRIPTION
When the session is created in multi-thread way.
The fix adds _semaphoreSlim.

closes: https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client/discussions/138