### PR TITLE
Use TotalSeconds to set x-max-age

### DIFF
--- a/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
@@ -381,7 +381,7 @@ namespace RabbitMQ.AMQP.Client.Impl
         {
             Utils.ValidatePositive("x-max-age", (long)maxAge.TotalMilliseconds,
                 (long)_parent._tenYears.TotalMilliseconds);
-            _parent._queueArguments["x-max-age"] = $"{maxAge.Seconds}s";
+            _parent._queueArguments["x-max-age"] = $"{maxAge.TotalSeconds}s";
             return this;
         }
 

--- a/Tests/Management/ManagementTests.cs
+++ b/Tests/Management/ManagementTests.cs
@@ -155,7 +155,7 @@ public class ManagementTests(ITestOutputHelper testOutputHelper) : IntegrationTe
             .MaxLengthBytes(ByteCapacity.Kb(1024))
             .LeaderLocator(LeaderLocatorStrategy.Balanced)
             .Stream()
-            .MaxAge(TimeSpan.FromSeconds(10))
+            .MaxAge(TimeSpan.FromMinutes(10))
             .MaxSegmentSizeBytes(ByteCapacity.Kb(1024))
             .InitialClusterSize(1)
             .FileSizePerChunk(ByteCapacity.Kb(1024))
@@ -163,7 +163,7 @@ public class ManagementTests(ITestOutputHelper testOutputHelper) : IntegrationTe
             .DeclareAsync();
 
         Assert.Equal(_queueName, queueInfo.Name());
-        Assert.Equal("10s", queueInfo.Arguments()["x-max-age"]);
+        Assert.Equal("600s", queueInfo.Arguments()["x-max-age"]);
         Assert.Equal(1024000L, queueInfo.Arguments()["x-stream-max-segment-size-bytes"]);
         Assert.Equal(1, queueInfo.Arguments()["x-initial-cluster-size"]);
         Assert.Equal("balanced", queueInfo.Arguments()["x-queue-leader-locator"]);


### PR DESCRIPTION
- Change use of `maxAge.Seconds` to `maxAge.TotalSeconds` in `AmqpStreamSpecification.MaxAge`. This fixes a bug where passing in any `maxAge`  with a zero value in the seconds position will set "x-max-age" to "0s", resulting in an 'invalid_max_age' error from RabbitMQ.
- Change `maxAge` value to 10 minutes in `ManagementTests.DeclareStreamQueueWithArguments` to demonstrate the bug and the fix.