### PR TITLE
fix: preserve broker URIs in ConnectionSettingsBuilder.From

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ All notable changes to this project will be documented in this file.
 ### Highlights
 - First stable 1.0 release.
 
+### Fix
+- `ConnectionSettingsBuilder.From` now copies cluster broker URIs in order (with correct virtual host path) instead of rebuilding from resolved addresses, and preserves WebSocket broker URIs including the resource path.
+
 ### Changed
 - Update AMQP.Net Lite to 2.5.1 by @Gsantomaggio in [#158](https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client/pull/158)
 - Improve examples by @Gsantomaggio in [#162](https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client/pull/162)

--- a/RabbitMQ.AMQP.Client/ConnectionSettings.cs
+++ b/RabbitMQ.AMQP.Client/ConnectionSettings.cs
@@ -46,9 +46,10 @@ namespace RabbitMQ.AMQP.Client
 
         /// <summary>
         /// From creates a new ConnectionSettingsBuilder from an existing ConnectionSettings instance.
-        /// It copies all the properties from the given ConnectionSettings instance to the new ConnectionSettingsBuilder instance.
-        /// It can be used to create a new ConnectionSettings instance that is similar to an existing one,
-        /// but with some properties changed.
+        /// It copies the settings into the builder so you can change some properties and call <see cref="Build"/>.
+        /// For <see cref="ClusterConnectionSettings"/>, the original broker URIs (including virtual host in the path)
+        /// and declaration order are preserved. For WebSocket (<c>ws</c>/<c>wss</c>) transports, the broker URI
+        /// (including the WebSocket resource path) is preserved via <see cref="Uri"/>.
         /// </summary>
         /// <param name="settings"> settings where to start</param>
         /// <returns></returns>
@@ -58,16 +59,7 @@ namespace RabbitMQ.AMQP.Client
             {
                 return new ConnectionSettingsBuilder()
                 {
-                    _uris = clusterConnectionSettings.Addresses.Select(a =>
-                        new UriBuilder()
-                        {
-                            Scheme = a.Scheme,
-                            Host = a.Host,
-                            Port = a.Port,
-                            UserName = a.User,
-                            Password = a.Password,
-                            Path = a.Path
-                        }.Uri).ToList(),
+                    _uris = clusterConnectionSettings.BrokerUris.ToList(),
                     _uriSelector = clusterConnectionSettings.UriSelector,
                     _containerId = clusterConnectionSettings.ContainerId,
                     _saslMechanism = clusterConnectionSettings.SaslMechanism,
@@ -75,6 +67,21 @@ namespace RabbitMQ.AMQP.Client
                     _maxFrameSize = clusterConnectionSettings.MaxFrameSize,
                     _tlsSettings = clusterConnectionSettings.TlsSettings,
                     _oAuth2Options = clusterConnectionSettings.OAuth2Options,
+                    _affinity = settings.Affinity
+                };
+            }
+
+            if (Utils.IsWebSocketScheme(settings.Scheme))
+            {
+                return new ConnectionSettingsBuilder()
+                {
+                    _uri = BuildWebSocketBrokerUri(settings),
+                    _containerId = settings.ContainerId,
+                    _saslMechanism = settings.SaslMechanism,
+                    _recoveryConfiguration = settings.Recovery,
+                    _maxFrameSize = settings.MaxFrameSize,
+                    _tlsSettings = settings.TlsSettings,
+                    _oAuth2Options = settings.OAuth2Options,
                     _affinity = settings.Affinity
                 };
             }
@@ -259,6 +266,34 @@ namespace RabbitMQ.AMQP.Client
             {
                 throw new ArgumentOutOfRangeException("uris", "Do not set both Uri and Uris");
             }
+        }
+
+        private static Uri BuildWebSocketBrokerUri(ConnectionSettings settings)
+        {
+            var ub = new UriBuilder
+            {
+                Scheme = settings.Scheme,
+                Host = settings.Host,
+                Path = string.IsNullOrWhiteSpace(settings.Path) ? "/" : settings.Path,
+            };
+
+            if (settings.Port > 0)
+            {
+                ub.Port = settings.Port;
+            }
+
+            if (settings.OAuth2Options is not null)
+            {
+                ub.UserName = string.Empty;
+                ub.Password = string.Empty;
+            }
+            else
+            {
+                ub.UserName = settings.User ?? string.Empty;
+                ub.Password = settings.Password ?? string.Empty;
+            }
+
+            return ub.Uri;
         }
     }
 
@@ -673,6 +708,12 @@ namespace RabbitMQ.AMQP.Client
         }
 
         internal IUriSelector? UriSelector => _uriSelector;
+
+        /// <summary>
+        /// Original broker URIs in declaration order (used for topology copy / <see cref="ConnectionSettingsBuilder.From"/>).
+        /// </summary>
+        internal IReadOnlyList<Uri> BrokerUris => _uris;
+
         internal override IList<Address> Addresses => _uriToAddress.Values.ToList();
     }
 

--- a/RabbitMQ.AMQP.Client/Utils.cs
+++ b/RabbitMQ.AMQP.Client/Utils.cs
@@ -251,6 +251,10 @@ namespace RabbitMQ.AMQP.Client
             }
         }
 
+        internal static bool IsWebSocketScheme(string scheme) =>
+            scheme.Equals("ws", StringComparison.InvariantCultureIgnoreCase) ||
+            scheme.Equals("wss", StringComparison.InvariantCultureIgnoreCase);
+
         internal static void ValidateMessageAnnotations(Dictionary<string, object> annotations)
         {
             foreach (KeyValuePair<string, object> kvp in annotations)

--- a/Tests/ConnectionTests/ConnectionSettingsTests.cs
+++ b/Tests/ConnectionTests/ConnectionSettingsTests.cs
@@ -313,6 +313,47 @@ public class ConnectionSettingsTests(ITestOutputHelper testOutputHelper)
     }
 
     [Fact]
+    public void ConnectionSettingsBuilderFromRoundTripsClusterSettings()
+    {
+        const string scheme = "amqps";
+        const string host = "rabbitmq-host.foo.baz.com";
+        const string vhost = "/frazzle";
+        string user = RandomString(10);
+        string pass = RandomString(10);
+
+        var uri0 = new Uri($"{scheme}://{user}:{pass}@{host}:5671/%2Ffrazzle");
+        var uri1 = new Uri($"{scheme}://{user}:{pass}@{host}:5681/%2Ffrazzle");
+        var uri2 = new Uri($"{scheme}://{user}:{pass}@{host}:5691/%2Ffrazzle");
+
+        List<Uri> uris = [uri0, uri1, uri2];
+        var selector = new RandomUriSelector();
+        var original = new ClusterConnectionSettings(uris, selector);
+        ConnectionSettings rebuilt = ConnectionSettingsBuilder.From(original).Build();
+
+        Assert.IsType<ClusterConnectionSettings>(rebuilt);
+        Assert.Equal(vhost, rebuilt.VirtualHost);
+        Assert.Equal(original, rebuilt);
+        Assert.Equal(original.GetHashCode(), rebuilt.GetHashCode());
+    }
+
+    [Fact]
+    public void ConnectionSettingsBuilderFromRoundTripsWebSocketBrokerUri()
+    {
+        string user = RandomString(8);
+        string pass = RandomString(8);
+        var uri = new Uri($"wss://{user}:{pass}@localhost:15673/custom-ws-path");
+        var original = new ConnectionSettings(uri);
+        ConnectionSettings copy = ConnectionSettingsBuilder.From(original).Build();
+
+        Assert.Equal(original.Scheme, copy.Scheme);
+        Assert.Equal(original.Host, copy.Host);
+        Assert.Equal(original.Port, copy.Port);
+        Assert.Equal(original.User, copy.User);
+        Assert.Equal(original.Password, copy.Password);
+        Assert.Equal(original.Path, copy.Path);
+    }
+
+    [Fact]
     public void BuilderThrowsWhenUriAndUrisBothSet()
     {
         const string scheme = "amqps";


### PR DESCRIPTION
Cluster settings now copy the original broker URI list (order and vhost path) instead of rebuilding from resolved addresses. WebSocket settings are copied via a reconstructed broker URI so the resource path is kept.

Tests cover cluster and WebSocket round-trips; changelog updated.

Fixes #163 