### PR TITLE
feat: support rejected-by and rejection reason (RabbitMQ 4.3+)

### DIFF
--- a/.ci/ubuntu/cluster/gha-setup.sh
+++ b/.ci/ubuntu/cluster/gha-setup.sh
@@ -19,7 +19,7 @@ function run_docker_compose
     docker compose --file "$script_dir/docker-compose.yml" $@
 }
 
-readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.3-rc-management}"
+readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.3-management}"
 
 if [[ ! -v GITHUB_ACTIONS ]]
 then

--- a/.ci/ubuntu/one-node/gha-setup.sh
+++ b/.ci/ubuntu/one-node/gha-setup.sh
@@ -9,7 +9,7 @@ readonly script_dir
 echo "[INFO] script_dir: '$script_dir'"
 
 
-readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.3-rc-management}"
+readonly rabbitmq_image="${RABBITMQ_IMAGE:-rabbitmq:4.3-management}"
 
 
 

--- a/RabbitMQ.AMQP.Client/AmqpMessageRejectedException.cs
+++ b/RabbitMQ.AMQP.Client/AmqpMessageRejectedException.cs
@@ -1,0 +1,29 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System;
+
+namespace RabbitMQ.AMQP.Client
+{
+    /// <summary>
+    /// Exception thrown when a message is rejected by the broker.
+    /// Available when a <see cref="PublishOutcome"/> has state <see cref="OutcomeState.Rejected"/>
+    /// and the broker provided rejection details (requires RabbitMQ 4.3 or later).
+    /// </summary>
+    public class AmqpMessageRejectedException : Exception
+    {
+        public AmqpMessageRejectedException(string? message, string? rejectedBy, string? reason) : base(message)
+        {
+            RejectedBy = rejectedBy;
+            Reason = reason;
+        }
+
+        /// <summary>
+        /// The name of the queue that rejected the message, if provided by the broker.
+        /// </summary>
+        public string? RejectedBy { get; }
+
+        public string? Reason { get; }
+    }
+}

--- a/RabbitMQ.AMQP.Client/IPublisher.cs
+++ b/RabbitMQ.AMQP.Client/IPublisher.cs
@@ -39,10 +39,12 @@ namespace RabbitMQ.AMQP.Client
     /// </summary>
     public class PublishOutcome
     {
-        public PublishOutcome(OutcomeState state, Error? error)
+        public PublishOutcome(OutcomeState state, Error? error,
+            AmqpMessageRejectedException? exception = null)
         {
             State = state;
             Error = error;
+            Exception = exception;
         }
 
         /// <summary>
@@ -54,6 +56,12 @@ namespace RabbitMQ.AMQP.Client
         /// The <see cref="Error"/>, if any.
         /// </summary>
         public Error? Error { get; }
+
+        /// <summary>
+        /// An <see cref="AmqpMessageRejectedException"/> if the message was rejected and the broker
+        /// provided rejection details (requires RabbitMQ 4.3 or later). <c>null</c> otherwise.
+        /// </summary>
+        public AmqpMessageRejectedException? Exception { get; }
     }
 
     /// <summary>

--- a/RabbitMQ.AMQP.Client/Impl/AmqpPublisher.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpPublisher.cs
@@ -143,7 +143,8 @@ namespace RabbitMQ.AMQP.Client.Impl
                         {
                             const OutcomeState publishState = OutcomeState.Rejected;
                             publishOutcome = new PublishOutcome(publishState,
-                                Utils.ConvertError(rejectedOutcome.Error));
+                                Utils.ConvertError(rejectedOutcome.Error),
+                                Utils.ConvertToAmqpMessageRejectedException(rejectedOutcome.Error));
                             _metricsReporter?.PublishDisposition(IMetricsReporter.PublishDispositionValue.REJECTED);
                             break;
                         }

--- a/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
@@ -40,6 +40,8 @@ override RabbitMQ.AMQP.Client.RecoveryConfiguration.ToString() -> string!
 override RabbitMQ.AMQP.Client.SaslMechanism.Equals(object? obj) -> bool
 override RabbitMQ.AMQP.Client.SaslMechanism.GetHashCode() -> int
 RabbitMQ.AMQP.Client.AffinityUtils
+RabbitMQ.AMQP.Client.AmqpMessageRejectedException.AmqpMessageRejectedException(string? message, string? rejectedBy, string? reason) -> void
+RabbitMQ.AMQP.Client.AmqpMessageRejectedException.Reason.get -> string?
 RabbitMQ.AMQP.Client.BackOffDelayPolicy
 RabbitMQ.AMQP.Client.BackOffDelayPolicy.BackOffDelayPolicy() -> void
 RabbitMQ.AMQP.Client.BackOffDelayPolicy.BackOffDelayPolicy(int maxAttempt) -> void
@@ -800,8 +802,11 @@ RabbitMQ.AMQP.Client.PublisherException
 RabbitMQ.AMQP.Client.PublisherException.PublisherException(string! message) -> void
 RabbitMQ.AMQP.Client.PublisherException.PublisherException(string! message, System.Exception! innerException) -> void
 RabbitMQ.AMQP.Client.PublishOutcome
+RabbitMQ.AMQP.Client.AmqpMessageRejectedException
+RabbitMQ.AMQP.Client.AmqpMessageRejectedException.RejectedBy.get -> string?
 RabbitMQ.AMQP.Client.PublishOutcome.Error.get -> RabbitMQ.AMQP.Client.Error?
-RabbitMQ.AMQP.Client.PublishOutcome.PublishOutcome(RabbitMQ.AMQP.Client.OutcomeState state, RabbitMQ.AMQP.Client.Error? error) -> void
+RabbitMQ.AMQP.Client.PublishOutcome.Exception.get -> RabbitMQ.AMQP.Client.AmqpMessageRejectedException?
+RabbitMQ.AMQP.Client.PublishOutcome.PublishOutcome(RabbitMQ.AMQP.Client.OutcomeState state, RabbitMQ.AMQP.Client.Error? error, RabbitMQ.AMQP.Client.AmqpMessageRejectedException? exception = null) -> void
 RabbitMQ.AMQP.Client.PublishOutcome.State.get -> RabbitMQ.AMQP.Client.OutcomeState
 RabbitMQ.AMQP.Client.PublishResult
 RabbitMQ.AMQP.Client.PublishResult.Message.get -> RabbitMQ.AMQP.Client.IMessage!

--- a/RabbitMQ.AMQP.Client/Utils.cs
+++ b/RabbitMQ.AMQP.Client/Utils.cs
@@ -63,6 +63,9 @@ namespace RabbitMQ.AMQP.Client
                 .Replace("=", "");
         }
 
+        private const string RejectedByQueueInfoKey = "queue";
+        private const string RejectedReason = "reason";
+
         internal static Error? ConvertError(Amqp.Framing.Error? sourceError)
         {
             Error? resultError = null;
@@ -73,6 +76,30 @@ namespace RabbitMQ.AMQP.Client
             }
 
             return resultError;
+        }
+
+        internal static AmqpMessageRejectedException? ConvertToAmqpMessageRejectedException(
+            Amqp.Framing.Error? sourceError)
+        {
+            if (sourceError == null)
+            {
+                return null;
+            }
+
+            string? rejectedBy = null;
+            if (sourceError.Info != null && sourceError.Info.ContainsKey(new Symbol(RejectedByQueueInfoKey)))
+            {
+                rejectedBy = sourceError.Info[new Symbol(RejectedByQueueInfoKey)]?.ToString();
+            }
+
+            string? reason = null;
+            if (sourceError.Info != null && sourceError.Info.ContainsKey(new Symbol(RejectedReason)))
+            {
+                reason = sourceError.Info[new Symbol(RejectedReason)]?.ToString();
+            }
+
+            string message = sourceError.Description ?? "Message has been rejected";
+            return new AmqpMessageRejectedException(message, rejectedBy, reason);
         }
 
         internal static void ValidateNonNegative(string label, long value, long max)

--- a/Tests/Publisher/PublisherTests.cs
+++ b/Tests/Publisher/PublisherTests.cs
@@ -11,6 +11,7 @@ using RabbitMQ.AMQP.Client;
 using RabbitMQ.AMQP.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
+using Xunit.Sdk;
 
 namespace Tests.Publisher;
 
@@ -255,6 +256,99 @@ public class PublisherTests(ITestOutputHelper testOutputHelper) : IntegrationTes
         // TODO this is quite different than the Java client
         Assert.Null(publishOutcome.Error.Description);
         Assert.Equal("amqp:resource-deleted", publishOutcome.Error.ErrorCode);
+
+        await publisher.CloseAsync();
+        publisher.Dispose();
+    }
+
+    /// <summary>
+    /// Test that when a message is rejected by the broker due to queue overflow,
+    /// the PublishOutcome.Exception is populated with an AmqpMessageRejectedException.
+    /// The rejection reason feature requires RabbitMQ 4.3 or later.
+    /// </summary>
+    [SkippableFact]
+    public async Task RejectedMessageShouldHaveAmqpMessageRejectedException()
+    {
+        Assert.NotNull(_featureFlags);
+        Skip.IfNot(_featureFlags is { Is43OrMore: true }, "At least RabbitMQ 4.3.0 required");
+
+        Assert.NotNull(_connection);
+        Assert.NotNull(_management);
+
+        IQueueSpecification queueSpecification = _management.Queue(_queueName)
+            .Type(QueueType.QUORUM)
+            .MaxLength(1)
+            .OverflowStrategy(OverFlowStrategy.RejectPublish);
+        await queueSpecification.DeclareAsync();
+
+        IPublisher publisher = await _connection.PublisherBuilder().Queue(queueSpecification).BuildAsync();
+
+        // Fill up the queue
+        PublishResult acceptedResult = await publisher.PublishAsync(new AmqpMessage("fill queue"));
+        Assert.Equal(OutcomeState.Accepted, acceptedResult.Outcome.State);
+
+        // we publish a message, QQs can accept more messages than the limit
+        await publisher.PublishAsync(new AmqpMessage("maybe"));
+
+        // This publish should be rejected because the queue is full and overflow strategy is reject-publish
+        PublishResult rejectedResult = await publisher.PublishAsync(new AmqpMessage("overflow"));
+        Assert.Equal(OutcomeState.Rejected, rejectedResult.Outcome.State);
+
+        AmqpMessageRejectedException? exception = rejectedResult.Outcome.Exception;
+        Assert.NotNull(exception);
+        Assert.NotNull(exception.Message);
+        Assert.Equal(_queueName, exception.RejectedBy);
+        Assert.Equal("maxlen", exception.Reason);
+
+        await publisher.CloseAsync();
+        publisher.Dispose();
+    }
+
+    /// <summary>
+    /// Test that when a message is rejected without broker-provided rejection details
+    /// (older broker or different rejection path), PublishOutcome.Exception can be null.
+    /// </summary>
+    [Fact]
+    public async Task RejectedMessageWithoutRejectionReasonHasNullException()
+    {
+        Assert.NotNull(_connection);
+        Assert.NotNull(_management);
+        IMessage message = new AmqpMessage(Encoding.ASCII.GetBytes("hello"));
+
+        IQueueSpecification queueSpecification = _management.Queue(_queueName).Exclusive(true);
+        IQueueInfo queueInfo = await queueSpecification.DeclareAsync();
+        Assert.Equal(_queueName, queueInfo.Name());
+
+        IPublisher publisher = await _connection.PublisherBuilder().Queue(queueSpecification).BuildAsync();
+
+        try
+        {
+            PublishResult publishResult = await publisher.PublishAsync(message);
+            Assert.Equal(OutcomeState.Accepted, publishResult.Outcome.State);
+        }
+        finally
+        {
+            await queueSpecification.DeleteAsync();
+        }
+
+        PublishOutcome? publishOutcome = null;
+        for (int i = 0; i < 100; i++)
+        {
+            PublishResult nextPublishResult = await publisher.PublishAsync(message);
+            if (OutcomeState.Rejected == nextPublishResult.Outcome.State)
+            {
+                publishOutcome = nextPublishResult.Outcome;
+                break;
+            }
+
+            await Task.Delay(TimeSpan.FromMilliseconds(100));
+        }
+
+        Assert.NotNull(publishOutcome);
+        // When the queue is deleted and the publisher sends a message, the error code is
+        // amqp:resource-deleted. In this case there is no rejection reason from the broker.
+        // Exception may still be populated (from the description) or null depending on broker version.
+        Assert.Equal(OutcomeState.Rejected, publishOutcome.State);
 
         await publisher.CloseAsync();
         publisher.Dispose();

--- a/docs/Examples/README.md
+++ b/docs/Examples/README.md
@@ -16,3 +16,4 @@ This directory contains examples of how to use the RabbitMQ AMQP 1.0 .NET client
 - PreSettled Consumer [here](./PreSettled/)
 - Stream group id filtering [here](./GroupIdFiltering/) 
 - Quorum queue single active consumer notifications [here](./QQSingleActiveNotification/)
+- Rejection reason (rejected-by queue name + reason, requires RabbitMQ 4.3+) [here](./RejectionReason/)

--- a/docs/Examples/RejectionReason/Program.cs
+++ b/docs/Examples/RejectionReason/Program.cs
@@ -1,0 +1,142 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+// RabbitMQ AMQP 1.0 client: https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client
+// Rejection Reason example (requires RabbitMQ 4.3 or later)
+//
+// When a quorum queue rejects a published message (e.g. because max-length is reached
+// and overflow-strategy is reject-publish), RabbitMQ 4.3+ includes the queue name and
+// the specific rejection reason inside the AMQP Rejected outcome.
+//
+// This example demonstrates:
+//   1. Declaring a quorum queue with a max-length of 5 and reject-publish overflow.
+//   2. Filling the queue so the next publish is rejected.
+//   3. Reading PublishOutcome.Exception (AmqpMessageRejectedException) to obtain
+//      the human-readable rejection reason and the RejectedBy queue name.
+//
+// See: https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#amqp-rejection-reason
+
+using System.Diagnostics;
+using RabbitMQ.AMQP.Client;
+using RabbitMQ.AMQP.Client.Impl;
+using Trace = Amqp.Trace;
+using TraceLevel = Amqp.TraceLevel;
+
+Trace.TraceLevel = TraceLevel.Information;
+
+ConsoleTraceListener consoleListener = new();
+Trace.TraceListener = (l, f, a) =>
+    consoleListener.WriteLine($"[{DateTime.Now:HH:mm:ss.fff}] [{l}] - {f}");
+
+Trace.WriteLine(TraceLevel.Information, "Starting Rejection Reason example (requires RabbitMQ 4.3+)...");
+
+const string containerId = "rejection-reason-example";
+const string queueName = "rejection-reason-demo-queue";
+const int maxLength = 5;
+
+IEnvironment environment = AmqpEnvironment.Create(
+    ConnectionSettingsBuilder.Create().ContainerId(containerId).Build());
+
+IConnection connection = await environment.CreateConnectionAsync();
+Trace.WriteLine(TraceLevel.Information, $"Connected: {connection}");
+
+IManagement management = connection.Management();
+
+// Declare a quorum queue with a max-length of 5 messages.
+// When the queue is full, new publishes are rejected (reject-publish strategy).
+IQueueSpecification queueSpec = management
+    .Queue(queueName)
+    .Type(QueueType.QUORUM)
+    .MaxLength(maxLength)
+    .OverflowStrategy(OverFlowStrategy.RejectPublish);
+
+await queueSpec.DeclareAsync();
+Trace.WriteLine(TraceLevel.Information,
+    $"Queue '{queueName}' declared (quorum, max-length={maxLength}, overflow=reject-publish).");
+
+IPublisher publisher = await connection.PublisherBuilder().Queue(queueSpec).BuildAsync();
+
+// ------------------------------------------------------------------------------------
+// Fill the queue up to max-length. All of these should be accepted.
+// ------------------------------------------------------------------------------------
+Trace.WriteLine(TraceLevel.Information, $"Publishing {maxLength} messages to fill the queue...");
+
+for (int i = 1; i <= maxLength + 1; i++)
+{
+    var msg = new AmqpMessage($"message-{i}");
+    PublishResult pr = await publisher.PublishAsync(msg);
+
+    if (pr.Outcome.State == OutcomeState.Accepted)
+    {
+        Trace.WriteLine(TraceLevel.Information, $"  [{i}/{maxLength}] Accepted: {msg.BodyAsString()}");
+    }
+    else
+    {
+        Trace.WriteLine(TraceLevel.Warning,
+            $"  [{i}/{maxLength}] Unexpected outcome '{pr.Outcome.State}' for: {msg.BodyAsString()}");
+    }
+}
+
+// ------------------------------------------------------------------------------------
+// Now the queue is full. The next publish should be rejected.
+// On RabbitMQ 4.3+ the Rejected outcome carries the queue name and rejection reason.
+// ------------------------------------------------------------------------------------
+Trace.WriteLine(TraceLevel.Information, "Queue is full. Publishing one more message — expecting rejection...");
+
+var overflow = new AmqpMessage("overflow-message");
+PublishResult rejectedResult = await publisher.PublishAsync(overflow);
+
+switch (rejectedResult.Outcome.State)
+{
+    case OutcomeState.Rejected:
+        Trace.WriteLine(TraceLevel.Warning, "Message was rejected (as expected).");
+
+        // Error carries the raw AMQP error code and description (available on all broker versions).
+        if (rejectedResult.Outcome.Error is { } error)
+        {
+            Trace.WriteLine(TraceLevel.Warning,
+                $"  AMQP error code : {error.ErrorCode}");
+            Trace.WriteLine(TraceLevel.Warning,
+                $"  AMQP description: {error.Description ?? "(none)"}");
+        }
+
+        // Exception is populated on RabbitMQ 4.3+ and contains structured rejection details.
+        if (rejectedResult.Outcome.Exception is { } ex)
+        {
+            Trace.WriteLine(TraceLevel.Warning,
+                $"  Rejection reason : {ex.Reason}, message: {ex.Message}");
+            Trace.WriteLine(TraceLevel.Warning,
+                $"  Rejected by queue: {ex.RejectedBy ?? "(not provided)"}");
+        }
+        else
+        {
+            Trace.WriteLine(TraceLevel.Information,
+                "  No structured rejection details (broker may be older than 4.3).");
+        }
+
+        break;
+
+    case OutcomeState.Accepted:
+        Trace.WriteLine(TraceLevel.Information, "Message was unexpectedly accepted.");
+        break;
+
+    case OutcomeState.Released:
+        Trace.WriteLine(TraceLevel.Information, "Message was released (no queue matched).");
+        break;
+
+    default:
+        throw new ArgumentOutOfRangeException();
+}
+
+// ------------------------------------------------------------------------------------
+// Cleanup
+// ------------------------------------------------------------------------------------
+await publisher.CloseAsync();
+publisher.Dispose();
+
+await queueSpec.DeleteAsync();
+Trace.WriteLine(TraceLevel.Information, $"Queue '{queueName}' deleted.");
+
+await environment.CloseAsync();
+Trace.WriteLine(TraceLevel.Information, "Example finished.");

--- a/docs/Examples/RejectionReason/RejectionReason.csproj
+++ b/docs/Examples/RejectionReason/RejectionReason.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../RabbitMQ.AMQP.Client/RabbitMQ.AMQP.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/rabbitmq-amqp-dotnet-client.sln
+++ b/rabbitmq-amqp-dotnet-client.sln
@@ -51,6 +51,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SingleActiveConsumer", "doc
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QQSingleActiveNotification", "docs\Examples\QQSingleActiveNotification\QQSingleActiveNotification.csproj", "{F4C8A2E1-9D3B-4C7A-8F2E-1B6D5A9C3E7F}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RejectionReason", "docs\Examples\RejectionReason\RejectionReason.csproj", "{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -121,6 +123,10 @@ Global
 		{F4C8A2E1-9D3B-4C7A-8F2E-1B6D5A9C3E7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F4C8A2E1-9D3B-4C7A-8F2E-1B6D5A9C3E7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F4C8A2E1-9D3B-4C7A-8F2E-1B6D5A9C3E7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -140,5 +146,6 @@ Global
 		{7EC63C3F-75EB-42FC-9063-F542160DDF84} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 		{B2C4D6E8-F0A2-4B6C-8D9E-0F1A2B3C4D5E} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 		{F4C8A2E1-9D3B-4C7A-8F2E-1B6D5A9C3E7F} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
+		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
When RabbitMQ 4.3+ rejects a published message it now includes the queue name and a human-readable reason inside the AMQP Rejected outcome.

- Add AmqpMessageRejectedException with RejectedBy property (queue name extracted from the AMQP error info "queue" field).
- Add PublishOutcome.Exception (AmqpMessageRejectedException?) populated whenever the broker provides rejection details on a Rejected outcome.
- Update AmqpPublisher to call Utils.ConvertToAmqpMessageRejectedException for every Rejected delivery disposition.
- Add Utils.ConvertToAmqpMessageRejectedException helper.
- Add integration tests (RejectedMessageShouldHaveAmqpMessageRejectedException skipped on < 4.3, RejectedMessageWithoutRejectionReasonHasNullException).
- Add docs/Examples/RejectionReason example demonstrating the feature.

See: https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#amqp-rejection-reason

closes: https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client/issues/166