### PR TITLE
feat: support quorum queue delayed retry (RabbitMQ 4.3+)

### DIFF
--- a/.github/workflows/wf_build-and-test.yaml
+++ b/.github/workflows/wf_build-and-test.yaml
@@ -12,18 +12,18 @@ jobs:
       NUGET_CERT_REVOCATION_MODE: offline
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           # Note: the cache path is relative to the workspace directory
           # https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows#using-the-cache-action
           path: ~/installers
           key: ${{ runner.os }}-v0-${{ hashFiles('.ci/windows/versions.json') }}
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.nuget/packages
@@ -54,7 +54,7 @@ jobs:
       #     path: ${{ github.workspace }}/diag/
       - name: Maybe upload RabbitMQ logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rabbitmq-logs-integration-win32
           path: ~/AppData/Roaming/RabbitMQ/log/
@@ -62,12 +62,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Clone repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           global-json-file: global.json    
-      - uses: actions/cache@v4
+      - uses: actions/cache@v5
         with:
           path: |
             ~/.nuget/packages
@@ -101,7 +101,7 @@ jobs:
       #     path: ${{ github.workspace }}/diag/
       - name: Upload RabbitMQ logs (on failure)
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rabbitmq-logs-integration-ubuntu
           path: ${{ github.workspace }}/.ci/ubuntu/cluster/log/

--- a/RabbitMQ.AMQP.Client/IEntities.cs
+++ b/RabbitMQ.AMQP.Client/IEntities.cs
@@ -127,13 +127,18 @@ namespace RabbitMQ.AMQP.Client
         /// <summary>Delayed retry is not applied (default).</summary>
         Disabled,
 
+        // All and Failed are not ready yet.
+        // We will make it available in a future releases
+
         /// <summary>All returned messages are delayed, regardless of whether the delivery count was incremented.</summary>
+        [Obsolete("This status is not ready to use.", true)]
         All,
 
         /// <summary>
         /// Only messages with an incremented <c>delivery-count</c> are delayed.
         /// This happens for example when discarding a message via <c>IContext.Discard()</c>.
         /// </summary>
+        [Obsolete("This status is not ready to use.", true)]
         Failed,
 
         /// <summary>

--- a/RabbitMQ.AMQP.Client/IEntities.cs
+++ b/RabbitMQ.AMQP.Client/IEntities.cs
@@ -111,6 +111,38 @@ namespace RabbitMQ.AMQP.Client
         AtLeastOnce
     }
 
+    /// <summary>
+    /// Conditions for delaying a message when it is returned to a quorum queue.
+    /// <para>
+    /// The delay is calculated with linear back-off based on the message's delivery count:
+    /// <c>min(min_delay * delivery_count, max_delay)</c>. A per-message explicit delivery time
+    /// can also be set by adding the <c>x-opt-delivery-time</c> annotation (a Unix timestamp in
+    /// milliseconds) when requeuing a message with annotations.
+    /// </para>
+    /// <para>Delayed retry support for quorum queues is available as of RabbitMQ 4.3.</para>
+    /// </summary>
+    /// <seealso href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry</seealso>
+    public enum QuorumQueueDelayedRetryType
+    {
+        /// <summary>Delayed retry is not applied (default).</summary>
+        Disabled,
+
+        /// <summary>All returned messages are delayed, regardless of whether the delivery count was incremented.</summary>
+        All,
+
+        /// <summary>
+        /// Only messages with an incremented <c>delivery-count</c> are delayed.
+        /// This happens for example when discarding a message via <c>IContext.Discard()</c>.
+        /// </summary>
+        Failed,
+
+        /// <summary>
+        /// Only messages without an incremented <c>delivery-count</c> are delayed.
+        /// This happens for example when requeuing a message via <c>IContext.Requeue()</c>.
+        /// </summary>
+        Returned
+    }
+
     public interface IQuorumQueueSpecification
     {
         IQuorumQueueSpecification DeadLetterStrategy(QuorumQueueDeadLetterStrategy strategy);
@@ -120,6 +152,35 @@ namespace RabbitMQ.AMQP.Client
         IQuorumQueueSpecification QuorumInitialGroupSize(int size);
 
         IQuorumQueueSpecification QuorumTargetGroupSize(int size);
+
+        /// <summary>
+        /// Set the delayed retry type.
+        /// <para>
+        /// Defines the conditions for delaying a message when it is returned to the queue.
+        /// You must also call <see cref="DelayedRetryMin"/> to configure the minimum retry delay.
+        /// </para>
+        /// <para>Delayed retry support for quorum queues requires RabbitMQ 4.3+.</para>
+        /// </summary>
+        /// <param name="type">The delayed retry condition.</param>
+        /// <seealso href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry</seealso>
+        IQuorumQueueSpecification DelayedRetryType(QuorumQueueDelayedRetryType type);
+
+        /// <summary>
+        /// Set the minimum delay for delayed retry (in milliseconds).
+        /// <para>
+        /// The delay grows linearly with the delivery count: <c>min(min * delivery_count, max)</c>.
+        /// </para>
+        /// </summary>
+        /// <param name="min">Minimum retry delay. Must be positive.</param>
+        /// <seealso href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry</seealso>
+        IQuorumQueueSpecification DelayedRetryMin(TimeSpan min);
+
+        /// <summary>
+        /// Set the maximum delay for delayed retry (in milliseconds).
+        /// </summary>
+        /// <param name="max">Maximum retry delay. Must be positive.</param>
+        /// <seealso href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry</seealso>
+        IQuorumQueueSpecification DelayedRetryMax(TimeSpan max);
 
         IQueueSpecification Queue();
     }

--- a/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
@@ -458,8 +458,8 @@ namespace RabbitMQ.AMQP.Client.Impl
             _parent._queueArguments["x-delayed-retry-type"] = type switch
             {
                 QuorumQueueDelayedRetryType.Disabled => "disabled",
-                QuorumQueueDelayedRetryType.All => "all",
-                QuorumQueueDelayedRetryType.Failed => "failed",
+                // QuorumQueueDelayedRetryType.All => "all",
+                // QuorumQueueDelayedRetryType.Failed => "failed",
                 QuorumQueueDelayedRetryType.Returned => "returned",
                 _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
             };

--- a/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
@@ -453,6 +453,33 @@ namespace RabbitMQ.AMQP.Client.Impl
             return this;
         }
 
+        public IQuorumQueueSpecification DelayedRetryType(QuorumQueueDelayedRetryType type)
+        {
+            _parent._queueArguments["x-delayed-retry-type"] = type switch
+            {
+                QuorumQueueDelayedRetryType.Disabled => "disabled",
+                QuorumQueueDelayedRetryType.All => "all",
+                QuorumQueueDelayedRetryType.Failed => "failed",
+                QuorumQueueDelayedRetryType.Returned => "returned",
+                _ => throw new ArgumentOutOfRangeException(nameof(type), type, null)
+            };
+            return this;
+        }
+
+        public IQuorumQueueSpecification DelayedRetryMin(TimeSpan min)
+        {
+            Utils.ValidatePositive("x-delayed-retry-min", (long)min.TotalMilliseconds);
+            _parent._queueArguments["x-delayed-retry-min"] = (long)min.TotalMilliseconds;
+            return this;
+        }
+
+        public IQuorumQueueSpecification DelayedRetryMax(TimeSpan max)
+        {
+            Utils.ValidatePositive("x-delayed-retry-max", (long)max.TotalMilliseconds);
+            _parent._queueArguments["x-delayed-retry-max"] = (long)max.TotalMilliseconds;
+            return this;
+        }
+
         public IQueueSpecification Queue()
         {
             return _parent;

--- a/RabbitMQ.AMQP.Client/Impl/DeliveryContext.cs
+++ b/RabbitMQ.AMQP.Client/Impl/DeliveryContext.cs
@@ -38,7 +38,6 @@ namespace RabbitMQ.AMQP.Client.Impl
                 {
                     throw new ConsumerException("Link is closed");
                 }
-
                 _link.Accept(_message);
                 _unsettledMessageCounter.Decrement();
                 _metricsReporter?.ConsumeDisposition(IMetricsReporter.ConsumeDispositionValue.ACCEPTED);

--- a/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
@@ -516,6 +516,9 @@ RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.Type(RabbitMQ.AMQP.Client.Queue
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.AmqpQuorumSpecification(RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification! parent) -> void
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DeadLetterStrategy(RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy strategy) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
+RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DelayedRetryMax(System.TimeSpan max) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
+RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DelayedRetryMin(System.TimeSpan min) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
+RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DelayedRetryType(RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType type) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DeliveryLimit(int limit) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.Queue() -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.QuorumInitialGroupSize(int size) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
@@ -717,6 +720,9 @@ RabbitMQ.AMQP.Client.IQueueSpecification.Stream() -> RabbitMQ.AMQP.Client.IStrea
 RabbitMQ.AMQP.Client.IQueueSpecification.Type(RabbitMQ.AMQP.Client.QueueType queueType) -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DeadLetterStrategy(RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy strategy) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
+RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DelayedRetryMax(System.TimeSpan max) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
+RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DelayedRetryMin(System.TimeSpan min) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
+RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DelayedRetryType(RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType type) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DeliveryLimit(int limit) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification.Queue() -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification.QuorumInitialGroupSize(int size) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
@@ -819,6 +825,11 @@ RabbitMQ.AMQP.Client.QueueType.STREAM = 2 -> RabbitMQ.AMQP.Client.QueueType
 RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy
 RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy.AtLeastOnce = 1 -> RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy
 RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy.AtMostOnce = 0 -> RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy
+RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType
+RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType.All = 1 -> RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType
+RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType.Disabled = 0 -> RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType
+RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType.Failed = 2 -> RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType
+RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType.Returned = 3 -> RabbitMQ.AMQP.Client.QuorumQueueDelayedRetryType
 RabbitMQ.AMQP.Client.RandomUriSelector
 RabbitMQ.AMQP.Client.RandomUriSelector.RandomUriSelector() -> void
 RabbitMQ.AMQP.Client.RandomUriSelector.Select(System.Collections.Generic.ICollection<System.Uri!>! uris) -> System.Uri!

--- a/Tests/Management/ManagementTests.cs
+++ b/Tests/Management/ManagementTests.cs
@@ -198,6 +198,33 @@ public class ManagementTests(ITestOutputHelper testOutputHelper) : IntegrationTe
         // NB: DisposeAsync will delete the queue with name _queueName
     }
 
+    [Theory]
+    [InlineData(QuorumQueueDelayedRetryType.All, "all")]
+    [InlineData(QuorumQueueDelayedRetryType.Failed, "failed")]
+    [InlineData(QuorumQueueDelayedRetryType.Returned, "returned")]
+    [InlineData(QuorumQueueDelayedRetryType.Disabled, "disabled")]
+    public async Task DeclareQuorumQueueWithDelayedRetryArguments(
+        QuorumQueueDelayedRetryType retryType, string expectedTypeValue)
+    {
+        Assert.NotNull(_connection);
+        Assert.NotNull(_management);
+
+        IQueueInfo queueInfo = await _management.Queue()
+            .Name(_queueName)
+            .Quorum()
+            .DelayedRetryType(retryType)
+            .DelayedRetryMin(TimeSpan.FromSeconds(1))
+            .DelayedRetryMax(TimeSpan.FromSeconds(60))
+            .Queue()
+            .DeclareAsync();
+
+        Assert.Equal(_queueName, queueInfo.Name());
+        Assert.Equal(expectedTypeValue, queueInfo.Arguments()["x-delayed-retry-type"]);
+        Assert.Equal(1000L, queueInfo.Arguments()["x-delayed-retry-min"]);
+        Assert.Equal(60000L, queueInfo.Arguments()["x-delayed-retry-max"]);
+        // NB: DisposeAsync will delete the queue with name _queueName
+    }
+
     [Fact]
     public async Task DeclareClassicQueueWithArguments()
     {

--- a/Tests/Management/ManagementTests.cs
+++ b/Tests/Management/ManagementTests.cs
@@ -199,8 +199,8 @@ public class ManagementTests(ITestOutputHelper testOutputHelper) : IntegrationTe
     }
 
     [Theory]
-    [InlineData(QuorumQueueDelayedRetryType.All, "all")]
-    [InlineData(QuorumQueueDelayedRetryType.Failed, "failed")]
+    // [InlineData(QuorumQueueDelayedRetryType.All, "all")]
+    // [InlineData(QuorumQueueDelayedRetryType.Failed, "failed")]
     [InlineData(QuorumQueueDelayedRetryType.Returned, "returned")]
     [InlineData(QuorumQueueDelayedRetryType.Disabled, "disabled")]
     public async Task DeclareQuorumQueueWithDelayedRetryArguments(

--- a/Tests/Management/MockManagementTests.cs
+++ b/Tests/Management/MockManagementTests.cs
@@ -122,8 +122,8 @@ public class MockManagementTests()
 
     [Theory]
     [InlineData(QuorumQueueDelayedRetryType.Disabled, "disabled")]
-    [InlineData(QuorumQueueDelayedRetryType.All, "all")]
-    [InlineData(QuorumQueueDelayedRetryType.Failed, "failed")]
+    // [InlineData(QuorumQueueDelayedRetryType.All, "all")]
+    // [InlineData(QuorumQueueDelayedRetryType.Failed, "failed")]
     [InlineData(QuorumQueueDelayedRetryType.Returned, "returned")]
     public void QuorumQueueDelayedRetryTypeSetsCorrectArgument(
         QuorumQueueDelayedRetryType retryType, string expectedValue)

--- a/Tests/Management/MockManagementTests.cs
+++ b/Tests/Management/MockManagementTests.cs
@@ -119,4 +119,61 @@ public class MockManagementTests()
            await management.RequestAsync(new Message(), [200]));
         Assert.Equal(State.Closed, management.State);
     }
+
+    [Theory]
+    [InlineData(QuorumQueueDelayedRetryType.Disabled, "disabled")]
+    [InlineData(QuorumQueueDelayedRetryType.All, "all")]
+    [InlineData(QuorumQueueDelayedRetryType.Failed, "failed")]
+    [InlineData(QuorumQueueDelayedRetryType.Returned, "returned")]
+    public void QuorumQueueDelayedRetryTypeSetsCorrectArgument(
+        QuorumQueueDelayedRetryType retryType, string expectedValue)
+    {
+        var management = new TestAmqpManagement();
+        var spec = new AmqpQueueSpecification(management);
+        spec.Quorum().DelayedRetryType(retryType);
+
+        Assert.Equal(expectedValue, spec.QueueArguments["x-delayed-retry-type"]);
+    }
+
+    [Fact]
+    public void QuorumQueueDelayedRetryMinSetsCorrectArgument()
+    {
+        var management = new TestAmqpManagement();
+        var spec = new AmqpQueueSpecification(management);
+        spec.Quorum().DelayedRetryMin(TimeSpan.FromSeconds(1));
+
+        Assert.Equal(1000L, spec.QueueArguments["x-delayed-retry-min"]);
+    }
+
+    [Fact]
+    public void QuorumQueueDelayedRetryMaxSetsCorrectArgument()
+    {
+        var management = new TestAmqpManagement();
+        var spec = new AmqpQueueSpecification(management);
+        spec.Quorum().DelayedRetryMax(TimeSpan.FromSeconds(30));
+
+        Assert.Equal(30000L, spec.QueueArguments["x-delayed-retry-max"]);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void QuorumQueueDelayedRetryMinThrowsForNonPositiveValue(int seconds)
+    {
+        var management = new TestAmqpManagement();
+        var spec = new AmqpQueueSpecification(management);
+        Assert.Throws<ArgumentException>(() =>
+            spec.Quorum().DelayedRetryMin(TimeSpan.FromSeconds(seconds)));
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    public void QuorumQueueDelayedRetryMaxThrowsForNonPositiveValue(int seconds)
+    {
+        var management = new TestAmqpManagement();
+        var spec = new AmqpQueueSpecification(management);
+        Assert.Throws<ArgumentException>(() =>
+            spec.Quorum().DelayedRetryMax(TimeSpan.FromSeconds(seconds)));
+    }
 }

--- a/docs/Examples/QQDelayedRetry/Program.cs
+++ b/docs/Examples/QQDelayedRetry/Program.cs
@@ -1,0 +1,148 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+// RabbitMQ AMQP 1.0 client: https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client
+// Quorum Queue Delayed Retry (RabbitMQ 4.3+)
+//
+// When a consumer discards a message (increments its delivery count), the broker
+// will delay redelivery using linear back-off:
+//
+//   delay = min(min_delay * delivery_count, max_delay)
+//
+// This prevents a fast retry storm when processing fails transiently.
+// A per-message explicit delivery time can also be set via the
+// "x-opt-delivery-time" message annotation (Unix timestamp in milliseconds).
+//
+// Queue arguments used:
+//   x-delayed-retry-type : "failed"   — delay only messages whose delivery-count was incremented
+//   x-delayed-retry-min  : 2000       — 2 s minimum delay
+//   x-delayed-retry-max  : 10000      — 10 s maximum delay (cap)
+//   x-max-delivery-limit : 5          — dead-letter after 5 failed attempts
+//
+// Expected output (approximate):
+//   [Consumer] msg#0 delivery-count=0 → failing (Discard)
+//   [Consumer] msg#0 delivery-count=1 → failing (Discard)   (~2 s later)
+//   [Consumer] msg#0 delivery-count=2 → failing (Discard)   (~4 s later)
+//   [Consumer] msg#0 delivery-count=3 → accepted            (~6 s later)
+//
+// Run: dotnet run
+
+using System.Diagnostics;
+using System.Globalization;
+using RabbitMQ.AMQP.Client;
+using RabbitMQ.AMQP.Client.Impl;
+using Trace = Amqp.Trace;
+using TraceLevel = Amqp.TraceLevel;
+
+// ── tracing ──────────────────────────────────────────────────────────────────
+Trace.TraceLevel = TraceLevel.Warning; // suppress low-level AMQP frames
+ConsoleTraceListener consoleListener = new();
+Trace.TraceListener = (l, f, a) =>
+    consoleListener.WriteLine(string.Format(CultureInfo.InvariantCulture, f, a ?? []));
+
+// ── connect ───────────────────────────────────────────────────────────────────
+IEnvironment environment = AmqpEnvironment.Create(
+    ConnectionSettingsBuilder.Create().ContainerId("qq-delayed-retry-example").Build());
+
+IConnection connection = await environment.CreateConnectionAsync();
+Console.WriteLine($"[{Now()}] Connected to the broker");
+
+// ── declare queue ─────────────────────────────────────────────────────────────
+// Uses DelayedRetryType.Failed so that only messages whose delivery-count is
+// incremented (i.e. discarded via context.Discard()) are subject to the delay.
+// Messages requeued without failure (context.Requeue()) are not delayed.
+IManagement management = connection.Management();
+const string queueName = "qq-delayed-retry-example";
+
+IQueueSpecification queueSpec = management.Queue(queueName)
+    .Quorum()
+        .DelayedRetryType(QuorumQueueDelayedRetryType.Returned)
+        .DelayedRetryMin(TimeSpan.FromSeconds(2))   // 2 s base delay
+        .DelayedRetryMax(TimeSpan.FromSeconds(10))  // cap at 10 s
+        .DeliveryLimit(5)                           // dead-letter after 5 attempts
+    .Queue();
+
+
+await queueSpec.DeclareAsync();
+Console.WriteLine($"[{Now()}] Queue '{queueName}' declared");
+Console.WriteLine($"[{Now()}] Delayed retry: type=failed, min=2 s, max=10 s, delivery-limit=5");
+Console.WriteLine();
+
+// ── consumer ──────────────────────────────────────────────────────────────────
+// Accept a message only on the 4th delivery (acquired-count >= 3).
+// On earlier deliveries, call context.Requeue() which sends a Modified outcome
+// with the acquired-count incremented, triggering the delayed retry.
+const int acceptOnAcquiredCount = 3;
+
+IConsumer consumer = await connection.ConsumerBuilder()
+    .Queue(queueName)
+    .MessageHandler((context, message) =>
+    {
+        Console.WriteLine("+++++++++++++++++++++++++++++++++++");
+        // RabbitMQ 4.3+ sets "x-acquired-count" on redeliveries.
+        long acquiredCount = 0;
+        try
+        {
+            acquiredCount = (long)message.Annotation("x-acquired-count"); 
+            
+            
+        }
+        catch { /* not present on the first delivery */ }
+
+        string msgId = message.BodyAsString();
+
+        if (acquiredCount < acceptOnAcquiredCount)
+        {
+            Console.WriteLine(
+                $"[{Now()}] [Consumer] {msgId} acquired count={acquiredCount} → failing (Requeue). " +
+                $"Next retry in ~2s");
+           
+            context.Requeue(); // increments acquired-count → triggers delayed retry
+        }
+        else
+        {
+            Console.WriteLine(
+                $"[{Now()}] [Consumer] {msgId} acquired-count={acquiredCount} → accepted ✓");
+            context.Accept();
+        }
+
+        return Task.CompletedTask;
+    })
+    .BuildAndStartAsync();
+
+// ── publisher ─────────────────────────────────────────────────────────────────
+IPublisher publisher = await connection.PublisherBuilder().Queue(queueName).BuildAsync();
+
+const int totalMessages = 1;
+Console.WriteLine($"[{Now()}] Publishing {totalMessages} messages...");
+Console.WriteLine();
+
+for (int i = 0; i < totalMessages; i++)
+{
+    var message = new AmqpMessage($"msg#{i}");
+    PublishResult pr = await publisher.PublishAsync(message);
+    Console.WriteLine(pr.Outcome.State == OutcomeState.Accepted
+        ? $"[{Now()}] [Publisher] msg#{i} confirmed by broker"
+        : $"[{Now()}] [Publisher] msg#{i} outcome: {pr.Outcome.State}");
+}
+
+Console.WriteLine();
+Console.WriteLine($"[{Now()}] Publishing done. Waiting for retries to complete...");
+Console.WriteLine("Press Enter to delete the queue and exit.");
+Console.ReadLine();
+
+// ── cleanup ───────────────────────────────────────────────────────────────────
+await publisher.CloseAsync();
+publisher.Dispose();
+
+await consumer.CloseAsync();
+consumer.Dispose();
+
+await queueSpec.DeleteAsync();
+Console.WriteLine($"[{Now()}] Queue '{queueName}' deleted");
+
+await environment.CloseAsync();
+Console.WriteLine($"[{Now()}] Done");
+
+static string Now() => DateTime.Now.ToString("HH:mm:ss.fff", CultureInfo.InvariantCulture);

--- a/docs/Examples/QQDelayedRetry/Program.cs
+++ b/docs/Examples/QQDelayedRetry/Program.cs
@@ -63,7 +63,6 @@ IQueueSpecification queueSpec = management.Queue(queueName)
         .DeliveryLimit(5)                           // dead-letter after 5 attempts
     .Queue();
 
-
 await queueSpec.DeclareAsync();
 Console.WriteLine($"[{Now()}] Queue '{queueName}' declared");
 Console.WriteLine($"[{Now()}] Delayed retry: type=failed, min=2 s, max=10 s, delivery-limit=5");
@@ -84,9 +83,8 @@ IConsumer consumer = await connection.ConsumerBuilder()
         long acquiredCount = 0;
         try
         {
-            acquiredCount = (long)message.Annotation("x-acquired-count"); 
-            
-            
+            acquiredCount = (long)message.Annotation("x-acquired-count");
+
         }
         catch { /* not present on the first delivery */ }
 
@@ -97,7 +95,7 @@ IConsumer consumer = await connection.ConsumerBuilder()
             Console.WriteLine(
                 $"[{Now()}] [Consumer] {msgId} acquired count={acquiredCount} → failing (Requeue). " +
                 $"Next retry in ~2s");
-           
+
             context.Requeue(); // increments acquired-count → triggers delayed retry
         }
         else

--- a/docs/Examples/QQDelayedRetry/Program.cs
+++ b/docs/Examples/QQDelayedRetry/Program.cs
@@ -15,16 +15,7 @@
 // "x-opt-delivery-time" message annotation (Unix timestamp in milliseconds).
 //
 // Queue arguments used:
-//   x-delayed-retry-type : "failed"   — delay only messages whose delivery-count was incremented
-//   x-delayed-retry-min  : 2000       — 2 s minimum delay
-//   x-delayed-retry-max  : 10000      — 10 s maximum delay (cap)
-//   x-max-delivery-limit : 5          — dead-letter after 5 failed attempts
-//
-// Expected output (approximate):
-//   [Consumer] msg#0 delivery-count=0 → failing (Discard)
-//   [Consumer] msg#0 delivery-count=1 → failing (Discard)   (~2 s later)
-//   [Consumer] msg#0 delivery-count=2 → failing (Discard)   (~4 s later)
-//   [Consumer] msg#0 delivery-count=3 → accepted            (~6 s later)
+//   x-delayed-retry-type : "Returned"   — no delay
 //
 // Run: dotnet run
 
@@ -49,8 +40,6 @@ IConnection connection = await environment.CreateConnectionAsync();
 Console.WriteLine($"[{Now()}] Connected to the broker");
 
 // ── declare queue ─────────────────────────────────────────────────────────────
-// Uses DelayedRetryType.Failed so that only messages whose delivery-count is
-// incremented (i.e. discarded via context.Discard()) are subject to the delay.
 // Messages requeued without failure (context.Requeue()) are not delayed.
 IManagement management = connection.Management();
 const string queueName = "qq-delayed-retry-example";
@@ -59,13 +48,10 @@ IQueueSpecification queueSpec = management.Queue(queueName)
     .Quorum()
         .DelayedRetryType(QuorumQueueDelayedRetryType.Returned)
         .DelayedRetryMin(TimeSpan.FromSeconds(2))   // 2 s base delay
-        .DelayedRetryMax(TimeSpan.FromSeconds(10))  // cap at 10 s
-        .DeliveryLimit(5)                           // dead-letter after 5 attempts
     .Queue();
 
 await queueSpec.DeclareAsync();
 Console.WriteLine($"[{Now()}] Queue '{queueName}' declared");
-Console.WriteLine($"[{Now()}] Delayed retry: type=failed, min=2 s, max=10 s, delivery-limit=5");
 Console.WriteLine();
 
 // ── consumer ──────────────────────────────────────────────────────────────────
@@ -112,7 +98,7 @@ IConsumer consumer = await connection.ConsumerBuilder()
 // ── publisher ─────────────────────────────────────────────────────────────────
 IPublisher publisher = await connection.PublisherBuilder().Queue(queueName).BuildAsync();
 
-const int totalMessages = 1;
+const int totalMessages = 5;
 Console.WriteLine($"[{Now()}] Publishing {totalMessages} messages...");
 Console.WriteLine();
 

--- a/docs/Examples/QQDelayedRetry/QQDelayedRetry.csproj
+++ b/docs/Examples/QQDelayedRetry/QQDelayedRetry.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../RabbitMQ.AMQP.Client/RabbitMQ.AMQP.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/Examples/README.md
+++ b/docs/Examples/README.md
@@ -17,3 +17,4 @@ This directory contains examples of how to use the RabbitMQ AMQP 1.0 .NET client
 - Stream group id filtering [here](./GroupIdFiltering/) 
 - Quorum queue single active consumer notifications [here](./QQSingleActiveNotification/)
 - Rejection reason (rejected-by queue name + reason, requires RabbitMQ 4.3+) [here](./RejectionReason/)
+- Quorum queue delayed retry with linear back-off (requires RabbitMQ 4.3+) [here](./QQDelayedRetry/)

--- a/rabbitmq-amqp-dotnet-client.sln
+++ b/rabbitmq-amqp-dotnet-client.sln
@@ -53,6 +53,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "QQSingleActiveNotification"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RejectionReason", "docs\Examples\RejectionReason\RejectionReason.csproj", "{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QQDelayedRetry", "docs\Examples\QQDelayedRetry\QQDelayedRetry.csproj", "{2A9A963B-0C00-4B99-AD0B-B187793CB382}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -127,6 +129,10 @@ Global
 		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A9A963B-0C00-4B99-AD0B-B187793CB382}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A9A963B-0C00-4B99-AD0B-B187793CB382}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A9A963B-0C00-4B99-AD0B-B187793CB382}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A9A963B-0C00-4B99-AD0B-B187793CB382}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -147,5 +153,6 @@ Global
 		{B2C4D6E8-F0A2-4B6C-8D9E-0F1A2B3C4D5E} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 		{F4C8A2E1-9D3B-4C7A-8F2E-1B6D5A9C3E7F} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
+		{2A9A963B-0C00-4B99-AD0B-B187793CB382} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
Add DelayedRetryType, DelayedRetryMin, and DelayedRetryMax to IQuorumQueueSpecification, allowing consumers to configure linear back-off redelivery on quorum queues (x-delayed-retry-type/min/max queue arguments, available as of RabbitMQ 4.3).

Includes unit and integration tests, a runnable example under docs/Examples/QQDelayedRetry, and public API tracking updates.