### PR TITLE
feat/add consumer timeout quorum jms

### DIFF
--- a/.ci/windows/versions.json
+++ b/.ci/windows/versions.json
@@ -1,4 +1,4 @@
 {
   "erlang": "27.2",
-  "rabbitmq": "4.2.0"
+  "rabbitmq": "4.3.0"
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,6 +55,7 @@ Example code demonstrating library usage:
 - `GettingStarted`
 - `Affinity`
 - `BatchDispositions`
+- `ConsumerTimeout` (quorum queue `x-consumer-timeout`)
 - `HAClient`
 - `OAuth2`
 - `OpenTelemetryIntegration`

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,7 +5,7 @@
   <ItemGroup>
     <!-- RabbitMQ.Amqp.Client -->
     <PackageVersion Include="AMQPNetLite" Version="2.5.2" />
-    <PackageVersion Include="AMQPNetLite.Core" Version="2.5.2" />
+    <PackageVersion Include="AMQPNetLite.Core" Version="2.5.3" />
     <PackageVersion Include="AMQPNetLite.WebSockets" Version="2.5.2" />
     <PackageVersion Include="OpenTelemetry" Version="1.10.0" />
     <PackageVersion Include="OpenTelemetry.Exporter.Console" Version="1.10.0" />

--- a/RabbitMQ.AMQP.Client/ConnectionSettings.cs
+++ b/RabbitMQ.AMQP.Client/ConnectionSettings.cs
@@ -9,6 +9,7 @@ using System.Net.Security;
 using System.Security.Authentication;
 using System.Security.Cryptography.X509Certificates;
 using Amqp;
+using Amqp.Handler;
 
 namespace RabbitMQ.AMQP.Client
 {
@@ -67,7 +68,7 @@ namespace RabbitMQ.AMQP.Client
                     _maxFrameSize = clusterConnectionSettings.MaxFrameSize,
                     _tlsSettings = clusterConnectionSettings.TlsSettings,
                     _oAuth2Options = clusterConnectionSettings.OAuth2Options,
-                    _affinity = settings.Affinity
+                    _affinity = settings.Affinity,
                 };
             }
 
@@ -82,7 +83,7 @@ namespace RabbitMQ.AMQP.Client
                     _maxFrameSize = settings.MaxFrameSize,
                     _tlsSettings = settings.TlsSettings,
                     _oAuth2Options = settings.OAuth2Options,
-                    _affinity = settings.Affinity
+                    _affinity = settings.Affinity,
                 };
             }
 
@@ -231,9 +232,10 @@ namespace RabbitMQ.AMQP.Client
         {
             // TODO this should do something similar to consolidate in the Java code
             ValidateUris();
+            ConnectionSettings settings;
             if (_uri is not null)
             {
-                return new ConnectionSettings(_uri,
+                settings = new ConnectionSettings(_uri,
                     _containerId, _saslMechanism,
                     _recoveryConfiguration,
                     _maxFrameSize,
@@ -241,23 +243,26 @@ namespace RabbitMQ.AMQP.Client
                     _oAuth2Options,
                     _affinity);
             }
-
-            if (_uris is not null)
+            else if (_uris is not null)
             {
-                return new ClusterConnectionSettings(_uris,
+                settings = new ClusterConnectionSettings(_uris,
                     _uriSelector,
                     _containerId, _saslMechanism,
                     _recoveryConfiguration,
                     _maxFrameSize,
                     _tlsSettings, _oAuth2Options, _affinity);
             }
+            else
+            {
+                settings = new ConnectionSettings(_scheme, _host, _port, _user,
+                    _password, _virtualHost,
+                    _containerId, _saslMechanism,
+                    _recoveryConfiguration,
+                    _maxFrameSize,
+                    _tlsSettings, _oAuth2Options, _affinity);
+            }
 
-            return new ConnectionSettings(_scheme, _host, _port, _user,
-                _password, _virtualHost,
-                _containerId, _saslMechanism,
-                _recoveryConfiguration,
-                _maxFrameSize,
-                _tlsSettings, _oAuth2Options, _affinity);
+            return settings;
         }
 
         private void ValidateUris()
@@ -312,6 +317,7 @@ namespace RabbitMQ.AMQP.Client
         private readonly IRecoveryConfiguration _recoveryConfiguration = new RecoveryConfiguration();
         private readonly IAffinity? _affinity = null;
         private readonly string _webSocketPath = "/";
+        private IHandler? _nativeHandler;
 
         public ConnectionSettings(Uri uri,
             string? containerId = null,
@@ -456,6 +462,11 @@ namespace RabbitMQ.AMQP.Client
         public IRecoveryConfiguration Recovery => _recoveryConfiguration;
 
         public IAffinity? Affinity => _affinity;
+
+        internal void SetNativeHandler(IHandler? handler)
+        {
+            _nativeHandler = handler;
+        }
 
         internal virtual Address Address => _address;
         internal OAuth2Options? OAuth2Options => _oAuth2Options;

--- a/RabbitMQ.AMQP.Client/Consts.cs
+++ b/RabbitMQ.AMQP.Client/Consts.cs
@@ -45,5 +45,8 @@ namespace RabbitMQ.AMQP.Client
         /// <summary>AMQP 1.0 link-state property: whether this link is the active single-active consumer.</summary>
         internal const string RabbitMqActiveProperty = "rabbitmq:active";
 
+        /// <summary>AMQP 1.0 attach property: consumer message lock timeout in milliseconds (quorum / JMS queues).</summary>
+        internal const string RabbitMqConsumerTimeoutProperty = "rabbitmq:consumer-timeout";
+
     }
 }

--- a/RabbitMQ.AMQP.Client/FeatureFlags.cs
+++ b/RabbitMQ.AMQP.Client/FeatureFlags.cs
@@ -36,6 +36,11 @@ namespace RabbitMQ.AMQP.Client
         /// link-state properties (<c>rabbitmq:active</c>). Requires RabbitMQ 4.3 or later.
         /// </summary>
         public bool IsQuorumSingleActiveConsumerFlowStateEnabled { get; internal set; } = false;
+        
+        /// <summary>
+        ///  https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#consumer-timeouts
+        /// </summary>
+        public bool IsConsumerTimeoutSupported { get; internal set; } = false;
         public bool Is43OrMore { get; internal set; } = false;
 
         public void Validate()

--- a/RabbitMQ.AMQP.Client/FeatureFlags.cs
+++ b/RabbitMQ.AMQP.Client/FeatureFlags.cs
@@ -36,7 +36,7 @@ namespace RabbitMQ.AMQP.Client
         /// link-state properties (<c>rabbitmq:active</c>). Requires RabbitMQ 4.3 or later.
         /// </summary>
         public bool IsQuorumSingleActiveConsumerFlowStateEnabled { get; internal set; } = false;
-        
+
         /// <summary>
         ///  https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#consumer-timeouts
         /// </summary>

--- a/RabbitMQ.AMQP.Client/IConsumer.cs
+++ b/RabbitMQ.AMQP.Client/IConsumer.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Amqp.Handler;
 
 namespace RabbitMQ.AMQP.Client
 {
@@ -35,6 +36,8 @@ namespace RabbitMQ.AMQP.Client
     /// <param name="consumer">The consumer whose SAC state was reported.</param>
     /// <param name="isActive"><c>true</c> when this consumer is the active SAC consumer; otherwise <c>false</c>.</param>
     public delegate void SingleActiveConsumerStateHandler(IConsumer consumer, bool isActive);
+
+    public delegate Task OnDeliveryRelease(IContext context, IMessage message);
 
     /// <summary>
     /// <para>API to consume messages from a RabbitMQ queue.</para>

--- a/RabbitMQ.AMQP.Client/IConsumer.cs
+++ b/RabbitMQ.AMQP.Client/IConsumer.cs
@@ -37,7 +37,13 @@ namespace RabbitMQ.AMQP.Client
     /// <param name="isActive"><c>true</c> when this consumer is the active SAC consumer; otherwise <c>false</c>.</param>
     public delegate void SingleActiveConsumerStateHandler(IConsumer consumer, bool isActive);
 
-    public delegate Task OnDeliveryRelease(IContext context, IMessage message);
+    /// <summary>
+    /// Raised when the delivery is released by the broker (AMQP 1.0 <c>released</c> outcome)
+    /// and the message is requeued to be delivered again.
+    /// For example: Consumer timeout feature in RabbitMQ 4.3+ can trigger this when a message
+    /// is not settled within the configured timeout.
+    /// </summary>
+    public delegate Task DeliveryReleaseHandler(IContext context, IMessage message);
 
     /// <summary>
     /// <para>API to consume messages from a RabbitMQ queue.</para>

--- a/RabbitMQ.AMQP.Client/IConsumerBuilder.cs
+++ b/RabbitMQ.AMQP.Client/IConsumerBuilder.cs
@@ -79,6 +79,11 @@ namespace RabbitMQ.AMQP.Client
         IStreamOptions Stream();
         IQuorumOptions Quorum();
 
+        /// <summary>
+        ///   JMS-queue consumer options (for example attach properties supported on JMS queue consumers).
+        /// </summary>
+        IJmsOptions Jms();
+
         Task<IConsumer> BuildAndStartAsync(CancellationToken cancellationToken = default);
 
         /// <summary>
@@ -105,6 +110,25 @@ namespace RabbitMQ.AMQP.Client
             /// At <see cref="BuildAndStartAsync"/> when <see cref="ConsumerSettleStrategy.DirectReplyTo"/> is selected.
             /// </exception>
             IQuorumOptions SingleActiveConsumerStateChanged(SingleActiveConsumerStateHandler? handler);
+
+            /// <summary>
+            ///   Sets the AMQP 1.0 attach property <c>rabbitmq:consumer-timeout</c> (milliseconds) for this consumer.
+            ///   Use with quorum queues (see RabbitMQ consumer timeout documentation).
+            /// </summary>
+            IQuorumOptions ConsumerTimeout(TimeSpan timeout);
+
+            IConsumerBuilder Builder();
+        }
+
+        /// <summary>
+        ///   Options for consumers of JMS queues.
+        /// </summary>
+        public interface IJmsOptions
+        {
+            /// <summary>
+            ///   Sets the AMQP 1.0 attach property <c>rabbitmq:consumer-timeout</c> (milliseconds) for this consumer.
+            /// </summary>
+            IJmsOptions ConsumerTimeout(TimeSpan timeout);
 
             IConsumerBuilder Builder();
         }

--- a/RabbitMQ.AMQP.Client/IConsumerBuilder.cs
+++ b/RabbitMQ.AMQP.Client/IConsumerBuilder.cs
@@ -117,7 +117,7 @@ namespace RabbitMQ.AMQP.Client
             /// </summary>
             IQuorumOptions ConsumerTimeout(TimeSpan timeout);
 
-            IQuorumOptions OnDeliveryRelease(OnDeliveryRelease onDeliveryRelease);
+            IQuorumOptions OnDeliveryRelease(DeliveryReleaseHandler deliveryReleaseHandler);
 
             IConsumerBuilder Builder();
         }

--- a/RabbitMQ.AMQP.Client/IConsumerBuilder.cs
+++ b/RabbitMQ.AMQP.Client/IConsumerBuilder.cs
@@ -117,6 +117,8 @@ namespace RabbitMQ.AMQP.Client
             /// </summary>
             IQuorumOptions ConsumerTimeout(TimeSpan timeout);
 
+            IQuorumOptions OnDeliveryRelease(OnDeliveryRelease onDeliveryRelease);
+
             IConsumerBuilder Builder();
         }
 

--- a/RabbitMQ.AMQP.Client/IEntities.cs
+++ b/RabbitMQ.AMQP.Client/IEntities.cs
@@ -85,6 +85,11 @@ namespace RabbitMQ.AMQP.Client
 
         IQuorumQueueSpecification Quorum();
 
+        /// <summary>
+        ///   Configures a JMS queue (<c>x-queue-type: jms</c>). Requires a broker that supports the JMS queue type.
+        /// </summary>
+        IJmsQueueSpecification Jms();
+
         IClassicQueueSpecification Classic();
 
         Task<ulong> PurgeAsync();
@@ -159,6 +164,11 @@ namespace RabbitMQ.AMQP.Client
         IQuorumQueueSpecification QuorumTargetGroupSize(int size);
 
         /// <summary>
+        ///   Sets the <c>x-consumer-timeout</c> queue argument (milliseconds).
+        /// </summary>
+        IQuorumQueueSpecification ConsumerTimeout(TimeSpan timeout);
+
+        /// <summary>
         /// Set the delayed retry type.
         /// <para>
         /// Defines the conditions for delaying a message when it is returned to the queue.
@@ -186,6 +196,19 @@ namespace RabbitMQ.AMQP.Client
         /// <param name="max">Maximum retry delay. Must be positive.</param>
         /// <seealso href="https://www.rabbitmq.com/docs/quorum-queues#delayed-retry">Delayed Retry</seealso>
         IQuorumQueueSpecification DelayedRetryMax(TimeSpan max);
+
+        IQueueSpecification Queue();
+    }
+
+    /// <summary>
+    ///   Optional arguments for JMS queues (<c>x-queue-type: jms</c>).
+    /// </summary>
+    public interface IJmsQueueSpecification
+    {
+        /// <summary>
+        ///   Sets the <c>x-consumer-timeout</c> queue argument (milliseconds).
+        /// </summary>
+        IJmsQueueSpecification ConsumerTimeout(TimeSpan timeout);
 
         IQueueSpecification Queue();
     }

--- a/RabbitMQ.AMQP.Client/IEntitiesInfo.cs
+++ b/RabbitMQ.AMQP.Client/IEntitiesInfo.cs
@@ -10,7 +10,8 @@ namespace RabbitMQ.AMQP.Client
     {
         QUORUM,
         CLASSIC,
-        STREAM
+        STREAM,
+        JMS
     }
 
     public interface IQueueInfo : IEntityInfo

--- a/RabbitMQ.AMQP.Client/IMetricsReporter.cs
+++ b/RabbitMQ.AMQP.Client/IMetricsReporter.cs
@@ -19,7 +19,9 @@ namespace RabbitMQ.AMQP.Client
         {
             ACCEPTED,
             DISCARDED,
-            REQUEUED
+            REQUEUED,
+            UNLOCK,
+
         };
 
         void ConnectionOpened();

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConnection.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConnection.cs
@@ -812,6 +812,7 @@ namespace RabbitMQ.AMQP.Client.Impl
             _featureFlags.IsFilterFeatureEnabled = Utils.SupportsFilterExpressions(brokerVersion);
 
             _featureFlags.IsQuorumSingleActiveConsumerFlowStateEnabled = Utils.Is4_3_OrMore(brokerVersion);
+            _featureFlags.IsConsumerTimeoutSupported = Utils.Is4_3_OrMore(brokerVersion);
             _featureFlags.Is43OrMore = Utils.Is4_3_OrMore(brokerVersion);
         }
     }

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConnection.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConnection.cs
@@ -10,7 +10,6 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Amqp;
-using Amqp.Framing;
 using Amqp.Sasl;
 using Amqp.Types;
 
@@ -56,6 +55,14 @@ namespace RabbitMQ.AMQP.Client.Impl
         /// See <see cref="AmqpConsumer"/>
         /// </summary>
         private readonly ConcurrentDictionary<Guid, IConsumer> _consumersDict = new();
+
+        /// <summary>
+        /// Internal handler that routes <see cref="Amqp.Handler.EventId.DeliveryStateChanged"/> events
+        /// from amqpnetlite to the appropriate <see cref="AmqpConsumer"/> instance.
+        /// Consumers register and unregister themselves via <see cref="RegisterConsumerDeliveryHandler"/>
+        /// and <see cref="UnregisterConsumerDeliveryHandler"/>.
+        /// </summary>
+        internal readonly ConnectionHandler _connectionHandler = new();
 
         private readonly TaskCompletionSource<bool> _connectionClosedTcs =
             Utils.CreateTaskCompletionSource<bool>();
@@ -354,6 +361,24 @@ namespace RabbitMQ.AMQP.Client.Impl
         }
 
         /// <summary>
+        /// Registers a consumer for <see cref="Amqp.Handler.EventId.DeliveryStateChanged"/> event routing.
+        /// Called from <see cref="AmqpConsumer.OpenAsync"/> after the receiver link is attached.
+        /// </summary>
+        internal void RegisterConsumerDeliveryHandler(string linkName, AmqpConsumer consumer)
+        {
+            _connectionHandler.RegisterConsumer(linkName, consumer);
+        }
+
+        /// <summary>
+        /// Unregisters a consumer from <see cref="Amqp.Handler.EventId.DeliveryStateChanged"/> event routing.
+        /// Called from <see cref="AmqpConsumer.CloseAsync"/>.
+        /// </summary>
+        internal void UnregisterConsumerDeliveryHandler(string linkName)
+        {
+            _connectionHandler.UnregisterConsumer(linkName);
+        }
+
+        /// <summary>
         /// Closes all the publishers. It is called when the connection is closed.
         /// </summary>
         // TODO cancellation token, parallel?
@@ -410,21 +435,6 @@ namespace RabbitMQ.AMQP.Client.Impl
                     return;
                 }
 
-                var open = new Open
-                {
-                    // Note: no need to set cf.AMQP.HostName
-                    HostName = $"vhost:{_connectionSettings.VirtualHost}",
-                    // Note: no need to set cf.AMQP.ContainerId
-                    ContainerId = _connectionSettings.ContainerId,
-                    Properties = new Fields() { [new Symbol("connection_name")] = _connectionSettings.ContainerId, }
-                };
-
-                if (_connectionSettings.MaxFrameSize > uint.MinValue)
-                {
-                    // Note: when set here, there is no need to set cf.AMQP.MaxFrameSize
-                    open.MaxFrameSize = _connectionSettings.MaxFrameSize;
-                }
-
                 ConnectionFactory cf;
 
                 if (_connectionSettings.Scheme.Equals("ws", StringComparison.OrdinalIgnoreCase) ||
@@ -435,6 +445,25 @@ namespace RabbitMQ.AMQP.Client.Impl
                 else
                 {
                     cf = new ConnectionFactory();
+                }
+
+                // Note: cf.AMQP.HostName / ContainerId / MaxFrameSize are used by the factory to
+                // build the AMQP OPEN frame when no explicit Open object is provided.
+                cf.AMQP.HostName = $"vhost:{_connectionSettings.VirtualHost}";
+                cf.AMQP.ContainerId = _connectionSettings.ContainerId;
+
+                if (_connectionSettings.MaxFrameSize > uint.MinValue)
+                {
+                    cf.AMQP.MaxFrameSize = (int)_connectionSettings.MaxFrameSize;
+                }
+
+                if (_connectionSettings.SaslMechanism == SaslMechanism.Anonymous)
+                {
+                    cf.SASL.Profile = SaslProfile.Anonymous;
+                }
+                else if (_connectionSettings.SaslMechanism == SaslMechanism.External)
+                {
+                    cf.SASL.Profile = SaslProfile.External;
                 }
 
                 if (_connectionSettings is { UseSsl: true, TlsSettings: not null })
@@ -460,26 +489,28 @@ namespace RabbitMQ.AMQP.Client.Impl
                     }
                 }
 
-                if (_connectionSettings.SaslMechanism == SaslMechanism.Anonymous)
-                {
-                    cf.SASL.Profile = SaslProfile.Anonymous;
-                }
-                else if (_connectionSettings.SaslMechanism == SaslMechanism.External)
-                {
-                    cf.SASL.Profile = SaslProfile.External;
-                }
-
-                void OnOpened(Amqp.IConnection connection, Open openOnOpened)
-                {
-                    HandleProperties(openOnOpened.Properties);
-                    Trace.WriteLine(TraceLevel.Verbose, $"{ToString()} is open");
-                    OnNewStatus(State.Open, null);
-                }
+                string connectionName = _connectionSettings.ContainerId;
+                var amqpConnectionHandler = new AmqpConnectionHandler(
+                    onLocalOpen: (open) =>
+                    {
+                        // Inject the connection_name property into the outgoing OPEN frame.
+                        open.Properties ??= new Fields() { };
+                        open.Properties[new Symbol("connection_name")] = connectionName;
+                    },
+                    onRemoteOpen: (remoteOpen) =>
+                    {
+                        HandleProperties(remoteOpen.Properties);
+                        Trace.WriteLine(TraceLevel.Verbose, $"{ToString()} is open");
+                        OnNewStatus(State.Open, null);
+                    },
+                    internalHandler: _connectionHandler);
 
                 try
                 {
                     Address address = _connectionSettings.Address;
-                    _nativeConnection = await cf.CreateAsync(address: address, open: open, onOpened: OnOpened)
+                    _nativeConnection = await cf.CreateAsync(address: address,
+                            cancellationToken: CancellationToken.None,
+                            handler: amqpConnectionHandler)
                         .ConfigureAwait(false);
                 }
                 catch (Exception ex)

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConnectionHandler.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConnectionHandler.cs
@@ -1,0 +1,84 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System;
+using Amqp;
+using Amqp.Framing;
+using Amqp.Handler;
+
+namespace RabbitMQ.AMQP.Client.Impl
+{
+    /// <summary>
+    /// Internal AMQP protocol handler used by <see cref="AmqpConnection"/>.
+    /// <list type="bullet">
+    ///   <item>
+    ///     On <see cref="EventId.ConnectionLocalOpen"/>: injects custom properties (e.g. <c>connection_name</c>)
+    ///     into the outgoing OPEN frame before it is sent.
+    ///   </item>
+    ///   <item>
+    ///     On <see cref="EventId.ConnectionRemoteOpen"/>: extracts broker capabilities and version
+    ///     from the incoming OPEN frame.
+    ///   </item>
+    ///   <item>
+    ///     All events are forwarded to an optional internal handler
+    ///     (e.g. the <see cref="ConnectionHandler"/> that dispatches <see cref="EventId.DeliveryStateChanged"/>
+    ///     to individual <see cref="AmqpConsumer"/> instances) and to an optional user-supplied handler.
+    ///   </item>
+    /// </list>
+    /// </summary>
+    internal sealed class AmqpConnectionHandler : IHandler
+    {
+        private readonly Action<Open> _onLocalOpen;
+        private readonly Action<Open> _onRemoteOpen;
+        private readonly IHandler? _internalHandler;
+
+        internal AmqpConnectionHandler(
+            Action<Open> onLocalOpen,
+            Action<Open> onRemoteOpen,
+            IHandler? internalHandler = null)
+        {
+            _onLocalOpen = onLocalOpen;
+            _onRemoteOpen = onRemoteOpen;
+            _internalHandler = internalHandler;
+        }
+
+        public bool CanHandle(EventId id)
+        {
+            if (id is EventId.ConnectionLocalOpen or EventId.ConnectionRemoteOpen)
+            {
+                return true;
+            }
+
+            return _internalHandler != null && _internalHandler.CanHandle(id);
+        }
+
+        public void Handle(Event protocolEvent)
+        {
+            switch (protocolEvent.Id)
+            {
+                case EventId.ConnectionLocalOpen:
+                    if (protocolEvent.Context is Open localOpen)
+                    {
+                        _onLocalOpen(localOpen);
+                    }
+
+                    break;
+
+                case EventId.ConnectionRemoteOpen:
+                    if (protocolEvent.Context is Open remoteOpen)
+                    {
+                        _onRemoteOpen(remoteOpen);
+                    }
+                    break;
+
+            }
+
+            if (_internalHandler != null && _internalHandler.CanHandle(protocolEvent.Id))
+            {
+                _internalHandler.Handle(protocolEvent);
+            }
+
+        }
+    }
+}

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConsumer.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConsumer.cs
@@ -109,8 +109,18 @@ namespace RabbitMQ.AMQP.Client.Impl
                 else
                 {
                     string address = AddressBuilderHelper.AddressBuilder().Queue(_configuration.Queue).Address();
+                    Fields? attachProperties = null;
+                    if (_configuration.ConsumerTimeoutMilliseconds is { } consumerTimeoutMs)
+                    {
+                        attachProperties = new Fields
+                        {
+                            { new Symbol(Consts.RabbitMqConsumerTimeoutProperty), consumerTimeoutMs }
+                        };
+                    }
+
                     attach = Utils.CreateAttach(address, DeliveryMode.AtLeastOnce, _id,
-                        _configuration.Filters, _configuration.SettleStrategy == ConsumerSettleStrategy.PreSettled);
+                        _configuration.Filters, _configuration.SettleStrategy == ConsumerSettleStrategy.PreSettled,
+                        attachProperties);
                 }
 
                 void OnAttached(ILink argLink, Attach argAttach)

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConsumer.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConsumer.cs
@@ -10,6 +10,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Amqp;
 using Amqp.Framing;
+using Amqp.Handler;
 using Amqp.Types;
 using Trace = Amqp.Trace;
 using TraceLevel = Amqp.TraceLevel;
@@ -159,6 +160,8 @@ namespace RabbitMQ.AMQP.Client.Impl
                 (_receiverLink, _attach) = await attachCompletedTcs.Task.WaitAsync(waitSpan)
                     .ConfigureAwait(false);
                 ValidateReceiverLink();
+
+                _amqpConnection.RegisterConsumerDeliveryHandler(_id.ToString(), this);
 
                 _receiverLink.SetCredit(_configuration.InitialCredits);
 
@@ -376,6 +379,29 @@ namespace RabbitMQ.AMQP.Client.Impl
         public long UnsettledMessageCount => _unsettledMessageCounter.Get();
 
         /// <summary>
+        /// Invoked by <see cref="ConnectionHandler"/> when the broker changes the delivery state of a message
+        /// on this consumer's receiver link (e.g. <c>RELEASED</c> due to a consumer-timeout on a quorum queue).
+        /// Decrements the unsettled-message counter so the consumer stays consistent.
+        /// </summary>
+        internal void OnDeliveryStateChanged(ReceiverLink receiverLink, IDelivery delivery)
+        {
+            Trace.WriteLine(TraceLevel.Verbose,
+                $"{ToString()} delivery state changed by broker: {delivery.State}");
+
+            if (_configuration.OnDeliveryRelease is not null && delivery.State is Released)
+            {
+                IContext context = _configuration.SettleStrategy switch
+                {
+                    ConsumerSettleStrategy.PreSettled => new PreSettledDeliveryContext(),
+                    _ => new TimeoutDeliveryContext(receiverLink, delivery.Message, _unsettledMessageCounter,
+                        _metricsReporter)
+                };
+
+                _configuration.OnDeliveryRelease?.Invoke(context, new AmqpMessage(delivery.Message));
+            }
+        }
+
+        /// <summary>
         /// Gets the queue name this consumer is attached to (from the link source address).
         /// </summary>
         public string Queue
@@ -440,6 +466,7 @@ namespace RabbitMQ.AMQP.Client.Impl
 
             _receiverLink = null;
             OnNewStatus(State.Closed, null);
+            _amqpConnection.UnregisterConsumerDeliveryHandler(_id.ToString());
             _amqpConnection.RemoveConsumer(_id);
         }
 

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
@@ -33,6 +33,12 @@ namespace RabbitMQ.AMQP.Client.Impl
         public Action<IConsumerBuilder.ListenerContext>? ListenerContext = null;
 
         public SingleActiveConsumerStateHandler? SingleActiveConsumerStateChangedHandler { get; set; }
+
+        /// <summary>
+        /// Per-consumer timeout in milliseconds for the AMQP 1.0 attach property <c>rabbitmq:consumer-timeout</c>
+        /// (quorum and JMS queues only). Set via <see cref="IConsumerBuilder.Quorum"/> / <see cref="IConsumerBuilder.Jms"/>.
+        /// </summary>
+        public uint? ConsumerTimeoutMilliseconds { get; set; }
     }
 
     /// <summary>
@@ -101,11 +107,23 @@ namespace RabbitMQ.AMQP.Client.Impl
             return new QuorumOptions(this, _configuration);
         }
 
+        public IConsumerBuilder.IJmsOptions Jms()
+        {
+            return new JmsOptions(this, _configuration);
+        }
+
         public async Task<IConsumer> BuildAndStartAsync(CancellationToken cancellationToken = default)
         {
             if (_configuration.Handler is null)
             {
                 throw new ConsumerException("Message handler is not set");
+            }
+
+            if (_configuration.ConsumerTimeoutMilliseconds is not null &&
+                _configuration.SettleStrategy == ConsumerSettleStrategy.DirectReplyTo)
+            {
+                throw new NotSupportedException(
+                    "Consumer timeout is not supported with ConsumerSettleStrategy.DirectReplyTo.");
             }
 
             if (_configuration.Filters[Consts.s_sqlFilterSymbol] is not null &&
@@ -142,14 +160,26 @@ namespace RabbitMQ.AMQP.Client.Impl
 
     public class QuorumOptions : IConsumerBuilder.IQuorumOptions
     {
+        private static readonly TimeSpan s_tenYears = TimeSpan.FromDays(365 * 10);
+
         private readonly IConsumerBuilder _consumerBuilder;
         private SingleActiveConsumerStateHandler? _changedHandler;
+        private uint? _consumerTimeoutMilliseconds;
+        private bool _consumerTimeoutTouched;
         private readonly ConsumerConfiguration _consumerConfiguration;
 
         internal QuorumOptions(IConsumerBuilder consumerBuilder, ConsumerConfiguration consumerConfiguration)
         {
             _consumerBuilder = consumerBuilder;
             _consumerConfiguration = consumerConfiguration;
+        }
+
+        public IConsumerBuilder.IQuorumOptions ConsumerTimeout(TimeSpan timeout)
+        {
+            Utils.ValidatePositive("ConsumerTimeout", (long)timeout.TotalMilliseconds, (long)s_tenYears.TotalMilliseconds);
+            _consumerTimeoutMilliseconds = (uint)timeout.TotalMilliseconds;
+            _consumerTimeoutTouched = true;
+            return this;
         }
 
         public IConsumerBuilder.IQuorumOptions SingleActiveConsumerStateChanged(
@@ -162,6 +192,45 @@ namespace RabbitMQ.AMQP.Client.Impl
         public IConsumerBuilder Builder()
         {
             _consumerConfiguration.SingleActiveConsumerStateChangedHandler = _changedHandler;
+            if (_consumerTimeoutTouched)
+            {
+                _consumerConfiguration.ConsumerTimeoutMilliseconds = _consumerTimeoutMilliseconds;
+            }
+
+            return _consumerBuilder;
+        }
+    }
+
+    public class JmsOptions : IConsumerBuilder.IJmsOptions
+    {
+        private static readonly TimeSpan s_tenYears = TimeSpan.FromDays(365 * 10);
+
+        private readonly IConsumerBuilder _consumerBuilder;
+        private uint? _consumerTimeoutMilliseconds;
+        private bool _consumerTimeoutTouched;
+        private readonly ConsumerConfiguration _consumerConfiguration;
+
+        internal JmsOptions(IConsumerBuilder consumerBuilder, ConsumerConfiguration consumerConfiguration)
+        {
+            _consumerBuilder = consumerBuilder;
+            _consumerConfiguration = consumerConfiguration;
+        }
+
+        public IConsumerBuilder.IJmsOptions ConsumerTimeout(TimeSpan timeout)
+        {
+            Utils.ValidatePositive("ConsumerTimeout", (long)timeout.TotalMilliseconds, (long)s_tenYears.TotalMilliseconds);
+            _consumerTimeoutMilliseconds = (uint)timeout.TotalMilliseconds;
+            _consumerTimeoutTouched = true;
+            return this;
+        }
+
+        public IConsumerBuilder Builder()
+        {
+            if (_consumerTimeoutTouched)
+            {
+                _consumerConfiguration.ConsumerTimeoutMilliseconds = _consumerTimeoutMilliseconds;
+            }
+
             return _consumerBuilder;
         }
     }

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
@@ -40,7 +40,7 @@ namespace RabbitMQ.AMQP.Client.Impl
         /// </summary>
         public uint? ConsumerTimeoutMilliseconds { get; set; }
 
-        public OnDeliveryRelease? OnDeliveryRelease { get; set; }
+        public DeliveryReleaseHandler? OnDeliveryRelease { get; set; }
     }
 
     /// <summary>
@@ -149,6 +149,15 @@ namespace RabbitMQ.AMQP.Client.Impl
                     throw new NotSupportedException(
                         "Single Active Consumer state change notification is not supported with ConsumerSettleStrategy.DirectReplyTo.");
                 }
+                
+                if (_configuration.OnDeliveryRelease is not null)
+                {
+                    if (!_amqpConnection._featureFlags.IsConsumerTimeoutSupported)
+                    {
+                        throw new NotSupportedException(
+                            "ConsumerTimeoutSupported is not supported by the connection. RabbitMQ 4.3.0 or later is required.");
+                    }
+                }
             }
 
             AmqpConsumer consumer = new(_amqpConnection, _configuration, _metricsReporter);
@@ -184,9 +193,9 @@ namespace RabbitMQ.AMQP.Client.Impl
             return this;
         }
 
-        public IConsumerBuilder.IQuorumOptions OnDeliveryRelease(OnDeliveryRelease onDeliveryRelease)
+        public IConsumerBuilder.IQuorumOptions OnDeliveryRelease(DeliveryReleaseHandler deliveryReleaseHandler)
         {
-            _consumerConfiguration.OnDeliveryRelease = onDeliveryRelease;
+            _consumerConfiguration.OnDeliveryRelease = deliveryReleaseHandler;
             return this;
         }
 

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
@@ -39,6 +39,8 @@ namespace RabbitMQ.AMQP.Client.Impl
         /// (quorum and JMS queues only). Set via <see cref="IConsumerBuilder.Quorum"/> / <see cref="IConsumerBuilder.Jms"/>.
         /// </summary>
         public uint? ConsumerTimeoutMilliseconds { get; set; }
+
+        public OnDeliveryRelease? OnDeliveryRelease { get; set; }
     }
 
     /// <summary>
@@ -179,6 +181,12 @@ namespace RabbitMQ.AMQP.Client.Impl
             Utils.ValidatePositive("ConsumerTimeout", (long)timeout.TotalMilliseconds, (long)s_tenYears.TotalMilliseconds);
             _consumerTimeoutMilliseconds = (uint)timeout.TotalMilliseconds;
             _consumerTimeoutTouched = true;
+            return this;
+        }
+
+        public IConsumerBuilder.IQuorumOptions OnDeliveryRelease(OnDeliveryRelease onDeliveryRelease)
+        {
+            _consumerConfiguration.OnDeliveryRelease = onDeliveryRelease;
             return this;
         }
 

--- a/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpConsumerBuilder.cs
@@ -149,7 +149,7 @@ namespace RabbitMQ.AMQP.Client.Impl
                     throw new NotSupportedException(
                         "Single Active Consumer state change notification is not supported with ConsumerSettleStrategy.DirectReplyTo.");
                 }
-                
+
                 if (_configuration.OnDeliveryRelease is not null)
                 {
                     if (!_amqpConnection._featureFlags.IsConsumerTimeoutSupported)

--- a/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpQueueSpecification.cs
@@ -258,6 +258,12 @@ namespace RabbitMQ.AMQP.Client.Impl
             return new AmqpQuorumSpecification(this);
         }
 
+        public IJmsQueueSpecification Jms()
+        {
+            Type(QueueType.JMS);
+            return new AmqpJmsSpecification(this);
+        }
+
         public IClassicQueueSpecification Classic()
         {
             Type(QueueType.CLASSIC);
@@ -298,9 +304,13 @@ namespace RabbitMQ.AMQP.Client.Impl
 
         public async Task<IQueueInfo> DeclareAsync()
         {
-            if (_queueArguments["x-queue-type"] is QueueType.QUORUM or QueueType.STREAM)
+            if (_queueArguments.TryGetValue("x-queue-type", out object? queueTypeArg) &&
+                queueTypeArg is string queueTypeStr &&
+                (string.Equals(queueTypeStr, "quorum", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(queueTypeStr, "stream", StringComparison.OrdinalIgnoreCase) ||
+                 string.Equals(queueTypeStr, "jms", StringComparison.OrdinalIgnoreCase)))
             {
-                // mandatory arguments for quorum queues and streams
+                // mandatory arguments for quorum queues, streams, and JMS queues
                 Exclusive(false).AutoDelete(false);
             }
 
@@ -477,6 +487,37 @@ namespace RabbitMQ.AMQP.Client.Impl
         {
             Utils.ValidatePositive("x-delayed-retry-max", (long)max.TotalMilliseconds);
             _parent._queueArguments["x-delayed-retry-max"] = (long)max.TotalMilliseconds;
+            return this;
+        }
+
+        public IQuorumQueueSpecification ConsumerTimeout(TimeSpan timeout)
+        {
+            Utils.ValidatePositive("ConsumerTimeout", (long)timeout.TotalMilliseconds,
+                (long)_parent._tenYears.TotalMilliseconds);
+            _parent._queueArguments["x-consumer-timeout"] = (long)timeout.TotalMilliseconds;
+            return this;
+        }
+
+        public IQueueSpecification Queue()
+        {
+            return _parent;
+        }
+    }
+
+    public class AmqpJmsSpecification : IJmsQueueSpecification
+    {
+        private readonly AmqpQueueSpecification _parent;
+
+        public AmqpJmsSpecification(AmqpQueueSpecification parent)
+        {
+            _parent = parent;
+        }
+
+        public IJmsQueueSpecification ConsumerTimeout(TimeSpan timeout)
+        {
+            Utils.ValidatePositive("ConsumerTimeout", (long)timeout.TotalMilliseconds,
+                (long)_parent._tenYears.TotalMilliseconds);
+            _parent._queueArguments["x-consumer-timeout"] = (long)timeout.TotalMilliseconds;
             return this;
         }
 

--- a/RabbitMQ.AMQP.Client/Impl/ConnectionHandler.cs
+++ b/RabbitMQ.AMQP.Client/Impl/ConnectionHandler.cs
@@ -1,0 +1,70 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System;
+using System.Collections.Concurrent;
+using Amqp;
+using Amqp.Handler;
+using Trace = Amqp.Trace;
+using TraceLevel = Amqp.TraceLevel;
+
+namespace RabbitMQ.AMQP.Client.Impl
+{
+    /// <summary>
+    /// Routes amqpnetlite protocol events (specifically <see cref="EventId.DeliveryStateChanged"/>)
+    /// to the appropriate <see cref="AmqpConsumer"/> based on the receiver link name.
+    /// One instance is shared per <see cref="AmqpConnection"/>.
+    /// </summary>
+    internal sealed class ConnectionHandler : IHandler
+    {
+        private readonly ConcurrentDictionary<string, AmqpConsumer> _consumers = new();
+
+        internal void RegisterConsumer(string linkName, AmqpConsumer consumer)
+        {
+            _consumers[linkName] = consumer;
+        }
+
+        internal void UnregisterConsumer(string linkName)
+        {
+            _consumers.TryRemove(linkName, out _);
+        }
+
+        public bool CanHandle(EventId id)
+        {
+            return id == EventId.DeliveryStateChanged;
+        }
+
+        public void Handle(Event protocolEvent)
+        {
+            if (protocolEvent.Id != EventId.DeliveryStateChanged)
+            {
+                return;
+            }
+
+            if (protocolEvent.Context is not IDelivery delivery)
+            {
+                return;
+            }
+
+            if (protocolEvent.Link is not ReceiverLink receiverLink)
+            {
+                return;
+            }
+
+            string linkName = receiverLink.Name;
+            if (_consumers.TryGetValue(linkName, out AmqpConsumer? consumer))
+            {
+                try
+                {
+                    consumer.OnDeliveryStateChanged(receiverLink, delivery);
+                }
+                catch (Exception ex)
+                {
+                    Trace.WriteLine(TraceLevel.Error,
+                        $"ConnectionHandler: error dispatching DeliveryStateChanged to {linkName}", ex);
+                }
+            }
+        }
+    }
+}

--- a/RabbitMQ.AMQP.Client/Impl/DeliveryContext.cs
+++ b/RabbitMQ.AMQP.Client/Impl/DeliveryContext.cs
@@ -328,4 +328,52 @@ namespace RabbitMQ.AMQP.Client.Impl
             throw new InvalidOperationException("Cannot create a batch context from a pre-settled delivery context.");
         }
     }
+
+    internal class TimeoutDeliveryContext : IContext
+    {
+        private readonly IReceiverLink _link;
+        private readonly Message _message;
+        private readonly UnsettledMessageCounter _unsettledMessageCounter;
+        private readonly IMetricsReporter? _metricsReporter;
+        public TimeoutDeliveryContext(IReceiverLink link, Message message, UnsettledMessageCounter unsettledMessageCounter,
+            IMetricsReporter? metricsReporter)
+        {
+            _link = link;
+            _message = message;
+            _unsettledMessageCounter = unsettledMessageCounter;
+            _metricsReporter = metricsReporter;
+        }
+
+        /// <summary>
+        /// <para>Accept the message (AMQP 1.0 <c>accepted</c> outcome).</para>
+        /// <para>In this case unlock the consumer form the timeout state</para>
+        /// </summary>
+        public void Accept()
+        {
+            try
+            {
+                if (_link.IsClosed)
+                {
+                    throw new ConsumerException("Link is closed");
+                }
+                _link.Accept(_message);
+                _unsettledMessageCounter.Decrement();
+                _metricsReporter?.ConsumeDisposition(IMetricsReporter.ConsumeDispositionValue.UNLOCK);
+            }
+            finally
+            {
+                _message.Dispose();
+            }
+        }
+
+        public void Discard() => throw new InvalidOperationException("Cannot discard a timed out delivery context. Only Accept is valid value");
+
+        public void Discard(Dictionary<string, object> annotations) => throw new InvalidOperationException("Cannot discard a timed out delivery context. Only Accept is valid value");
+
+        public void Requeue() => throw new InvalidOperationException("Cannot requeue a timed out delivery context. Only Accept is valid value");
+
+        public void Requeue(Dictionary<string, object> annotations) => throw new InvalidOperationException("Cannot requeue a timed out delivery context. Only Accept is valid value");
+
+        public IBatchContext Batch() => throw new InvalidOperationException("Cannot create a batch context from a timed out delivery context.");
+    }
 }

--- a/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
@@ -196,8 +196,12 @@ RabbitMQ.AMQP.Client.IConsumer.UnsettledMessageCount.get -> long
 RabbitMQ.AMQP.Client.IConsumerBuilder
 RabbitMQ.AMQP.Client.IConsumerBuilder.BuildAndStartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.AMQP.Client.IConsumer!>!
 RabbitMQ.AMQP.Client.IConsumerBuilder.InitialCredits(int initialCredits) -> RabbitMQ.AMQP.Client.IConsumerBuilder!
+RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions
+RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
+RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
+RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.SingleActiveConsumerStateChanged(RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler? handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions
 RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions.AbsoluteExpiryTime(System.DateTime absoluteExpiryTime) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions!
@@ -229,6 +233,7 @@ RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamOptions.Offset(System.DateTime time
 RabbitMQ.AMQP.Client.IConsumerBuilder.ListenerContext
 RabbitMQ.AMQP.Client.IConsumerBuilder.ListenerContext.ListenerContext(RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamOptions! streamOptions) -> void
 RabbitMQ.AMQP.Client.IConsumerBuilder.ListenerContext.StreamOptions.get -> RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamOptions!
+RabbitMQ.AMQP.Client.IConsumerBuilder.Jms() -> RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.MessageHandler(RabbitMQ.AMQP.Client.MessageHandler! handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder!
 RabbitMQ.AMQP.Client.IConsumerBuilder.Quorum() -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.Queue(RabbitMQ.AMQP.Client.IQueueSpecification! queueSpecification) -> RabbitMQ.AMQP.Client.IConsumerBuilder!
@@ -265,6 +270,9 @@ RabbitMQ.AMQP.Client.IExchangeSpecification.IsAutoDelete.get -> bool
 RabbitMQ.AMQP.Client.IExchangeSpecification.Name(string! exchangeName) -> RabbitMQ.AMQP.Client.IExchangeSpecification!
 RabbitMQ.AMQP.Client.IExchangeSpecification.Type(RabbitMQ.AMQP.Client.ExchangeType exchangeType) -> RabbitMQ.AMQP.Client.IExchangeSpecification!
 RabbitMQ.AMQP.Client.IExchangeSpecification.Type(string! exchangeType) -> RabbitMQ.AMQP.Client.IExchangeSpecification!
+RabbitMQ.AMQP.Client.IJmsQueueSpecification
+RabbitMQ.AMQP.Client.IJmsQueueSpecification.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IJmsQueueSpecification!
+RabbitMQ.AMQP.Client.IJmsQueueSpecification.Queue() -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.ILifeCycle
 RabbitMQ.AMQP.Client.ILifeCycle.ChangeState -> RabbitMQ.AMQP.Client.LifeCycleCallBack!
 RabbitMQ.AMQP.Client.ILifeCycle.CloseAsync() -> System.Threading.Tasks.Task!
@@ -397,6 +405,7 @@ RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder
 RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder.AmqpConsumerBuilder(RabbitMQ.AMQP.Client.Impl.AmqpConnection! connection, RabbitMQ.AMQP.Client.IMetricsReporter? metricsReporter) -> void
 RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder.BuildAndStartAsync(System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<RabbitMQ.AMQP.Client.IConsumer!>!
 RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder.InitialCredits(int initialCredits) -> RabbitMQ.AMQP.Client.IConsumerBuilder!
+RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder.Jms() -> RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions!
 RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder.MessageHandler(RabbitMQ.AMQP.Client.MessageHandler! handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder!
 RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder.Quorum() -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.Impl.AmqpConsumerBuilder.Queue(RabbitMQ.AMQP.Client.IQueueSpecification! queueSpec) -> RabbitMQ.AMQP.Client.IConsumerBuilder!
@@ -419,6 +428,10 @@ RabbitMQ.AMQP.Client.Impl.AmqpExchangeSpecification.ExchangeArguments.get -> Sys
 RabbitMQ.AMQP.Client.Impl.AmqpExchangeSpecification.ExchangeName.get -> string!
 RabbitMQ.AMQP.Client.Impl.AmqpExchangeSpecification.ExchangeType.get -> string!
 RabbitMQ.AMQP.Client.Impl.AmqpExchangeSpecification.IsAutoDelete.get -> bool
+RabbitMQ.AMQP.Client.Impl.AmqpJmsSpecification
+RabbitMQ.AMQP.Client.Impl.AmqpJmsSpecification.AmqpJmsSpecification(RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification! parent) -> void
+RabbitMQ.AMQP.Client.Impl.AmqpJmsSpecification.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IJmsQueueSpecification!
+RabbitMQ.AMQP.Client.Impl.AmqpJmsSpecification.Queue() -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpExchangeSpecification.Name(string! name) -> RabbitMQ.AMQP.Client.IExchangeSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpExchangeSpecification.Type(RabbitMQ.AMQP.Client.ExchangeType exchangeType) -> RabbitMQ.AMQP.Client.IExchangeSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpExchangeSpecification.Type(string! exchangeType) -> RabbitMQ.AMQP.Client.IExchangeSpecification!
@@ -509,12 +522,14 @@ RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.OverflowStrategy(RabbitMQ.AMQP.
 RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.PurgeAsync() -> System.Threading.Tasks.Task<ulong>!
 RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.QueueArguments.get -> System.Collections.Generic.Dictionary<object!, object!>!
 RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.QueueName.get -> string!
+RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.Jms() -> RabbitMQ.AMQP.Client.IJmsQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.Quorum() -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.SingleActiveConsumer(bool singleActiveConsumer) -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.Stream() -> RabbitMQ.AMQP.Client.IStreamSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification.Type(RabbitMQ.AMQP.Client.QueueType queueType) -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.AmqpQuorumSpecification(RabbitMQ.AMQP.Client.Impl.AmqpQueueSpecification! parent) -> void
+RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DeadLetterStrategy(RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy strategy) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DelayedRetryMax(System.TimeSpan max) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.Impl.AmqpQuorumSpecification.DelayedRetryMin(System.TimeSpan min) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
@@ -610,8 +625,12 @@ RabbitMQ.AMQP.Client.Impl.PreSettledDeliveryContext.Discard(System.Collections.G
 RabbitMQ.AMQP.Client.Impl.PreSettledDeliveryContext.PreSettledDeliveryContext() -> void
 RabbitMQ.AMQP.Client.Impl.PreSettledDeliveryContext.Requeue() -> void
 RabbitMQ.AMQP.Client.Impl.PreSettledDeliveryContext.Requeue(System.Collections.Generic.Dictionary<string!, object!>! annotations) -> void
+RabbitMQ.AMQP.Client.Impl.JmsOptions
+RabbitMQ.AMQP.Client.Impl.JmsOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
+RabbitMQ.AMQP.Client.Impl.JmsOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions!
 RabbitMQ.AMQP.Client.Impl.QuorumOptions
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
+RabbitMQ.AMQP.Client.Impl.QuorumOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.SingleActiveConsumerStateChanged(RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler? handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.Impl.RequesterAddressBuilder
 RabbitMQ.AMQP.Client.Impl.RequesterAddressBuilder.Requester() -> RabbitMQ.AMQP.Client.IRequesterBuilder!
@@ -714,11 +733,13 @@ RabbitMQ.AMQP.Client.IQueueSpecification.OverflowStrategy(RabbitMQ.AMQP.Client.O
 RabbitMQ.AMQP.Client.IQueueSpecification.PurgeAsync() -> System.Threading.Tasks.Task<ulong>!
 RabbitMQ.AMQP.Client.IQueueSpecification.QueueArguments.get -> System.Collections.Generic.Dictionary<object!, object!>!
 RabbitMQ.AMQP.Client.IQueueSpecification.QueueName.get -> string!
+RabbitMQ.AMQP.Client.IQueueSpecification.Jms() -> RabbitMQ.AMQP.Client.IJmsQueueSpecification!
 RabbitMQ.AMQP.Client.IQueueSpecification.Quorum() -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.IQueueSpecification.SingleActiveConsumer(bool singleActiveConsumer) -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.IQueueSpecification.Stream() -> RabbitMQ.AMQP.Client.IStreamSpecification!
 RabbitMQ.AMQP.Client.IQueueSpecification.Type(RabbitMQ.AMQP.Client.QueueType queueType) -> RabbitMQ.AMQP.Client.IQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification
+RabbitMQ.AMQP.Client.IQuorumQueueSpecification.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DeadLetterStrategy(RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy strategy) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DelayedRetryMax(System.TimeSpan max) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
 RabbitMQ.AMQP.Client.IQuorumQueueSpecification.DelayedRetryMin(System.TimeSpan min) -> RabbitMQ.AMQP.Client.IQuorumQueueSpecification!
@@ -820,6 +841,7 @@ RabbitMQ.AMQP.Client.PublishResult.Outcome.get -> RabbitMQ.AMQP.Client.PublishOu
 RabbitMQ.AMQP.Client.PublishResult.PublishResult(RabbitMQ.AMQP.Client.IMessage! message, RabbitMQ.AMQP.Client.PublishOutcome! outcome) -> void
 RabbitMQ.AMQP.Client.QueueType
 RabbitMQ.AMQP.Client.QueueType.CLASSIC = 1 -> RabbitMQ.AMQP.Client.QueueType
+RabbitMQ.AMQP.Client.QueueType.JMS = 3 -> RabbitMQ.AMQP.Client.QueueType
 RabbitMQ.AMQP.Client.QueueType.QUORUM = 0 -> RabbitMQ.AMQP.Client.QueueType
 RabbitMQ.AMQP.Client.QueueType.STREAM = 2 -> RabbitMQ.AMQP.Client.QueueType
 RabbitMQ.AMQP.Client.QuorumQueueDeadLetterStrategy

--- a/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
@@ -202,6 +202,7 @@ RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions.ConsumerTimeout(System.TimeSpa
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
+RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.OnDeliveryRelease(RabbitMQ.AMQP.Client.OnDeliveryRelease! onDeliveryRelease) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.SingleActiveConsumerStateChanged(RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler? handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions
 RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions.AbsoluteExpiryTime(System.DateTime absoluteExpiryTime) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions!
@@ -335,6 +336,7 @@ RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue
 RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue.ACCEPTED = 0 -> RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue
 RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue.DISCARDED = 1 -> RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue
 RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue.REQUEUED = 2 -> RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue
+RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue.UNLOCK = 3 -> RabbitMQ.AMQP.Client.IMetricsReporter.ConsumeDispositionValue
 RabbitMQ.AMQP.Client.IMetricsReporter.ConsumerClosed() -> void
 RabbitMQ.AMQP.Client.IMetricsReporter.ConsumerOpened() -> void
 RabbitMQ.AMQP.Client.IMetricsReporter.PublishDisposition(RabbitMQ.AMQP.Client.IMetricsReporter.PublishDispositionValue disposition) -> void
@@ -631,6 +633,7 @@ RabbitMQ.AMQP.Client.Impl.JmsOptions.ConsumerTimeout(System.TimeSpan timeout) ->
 RabbitMQ.AMQP.Client.Impl.QuorumOptions
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
+RabbitMQ.AMQP.Client.Impl.QuorumOptions.OnDeliveryRelease(RabbitMQ.AMQP.Client.OnDeliveryRelease! onDeliveryRelease) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.SingleActiveConsumerStateChanged(RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler? handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.Impl.RequesterAddressBuilder
 RabbitMQ.AMQP.Client.Impl.RequesterAddressBuilder.Requester() -> RabbitMQ.AMQP.Client.IRequesterBuilder!
@@ -793,6 +796,7 @@ RabbitMQ.AMQP.Client.LeaderLocatorStrategy.Balanced = 1 -> RabbitMQ.AMQP.Client.
 RabbitMQ.AMQP.Client.LeaderLocatorStrategy.ClientLocal = 0 -> RabbitMQ.AMQP.Client.LeaderLocatorStrategy
 RabbitMQ.AMQP.Client.LifeCycleCallBack
 RabbitMQ.AMQP.Client.MessageHandler
+RabbitMQ.AMQP.Client.OnDeliveryRelease
 RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler
 RabbitMQ.AMQP.Client.MetricsReporter
 RabbitMQ.AMQP.Client.MetricsReporter.ConnectionClosed() -> void

--- a/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
+++ b/RabbitMQ.AMQP.Client/PublicAPI.Unshipped.txt
@@ -117,6 +117,7 @@ RabbitMQ.AMQP.Client.DefaultAffinity.Attempts() -> uint
 RabbitMQ.AMQP.Client.DefaultAffinity.DefaultAffinity(string! queue, RabbitMQ.AMQP.Client.Operation operation, uint tentatives = 10) -> void
 RabbitMQ.AMQP.Client.DefaultAffinity.Operation() -> RabbitMQ.AMQP.Client.Operation
 RabbitMQ.AMQP.Client.DefaultAffinity.Queue() -> string!
+RabbitMQ.AMQP.Client.DeliveryReleaseHandler
 RabbitMQ.AMQP.Client.Error
 RabbitMQ.AMQP.Client.Error.Description.get -> string?
 RabbitMQ.AMQP.Client.Error.Error(string? errorCode, string? description) -> void
@@ -130,6 +131,7 @@ RabbitMQ.AMQP.Client.FeatureFlags
 RabbitMQ.AMQP.Client.FeatureFlags.FeatureFlags() -> void
 RabbitMQ.AMQP.Client.FeatureFlags.Is43OrMore.get -> bool
 RabbitMQ.AMQP.Client.FeatureFlags.IsBrokerCompatible.get -> bool
+RabbitMQ.AMQP.Client.FeatureFlags.IsConsumerTimeoutSupported.get -> bool
 RabbitMQ.AMQP.Client.FeatureFlags.IsDirectReplyToSupported.get -> bool
 RabbitMQ.AMQP.Client.FeatureFlags.IsFilterFeatureEnabled.get -> bool
 RabbitMQ.AMQP.Client.FeatureFlags.IsSqlFeatureEnabled.get -> bool
@@ -202,7 +204,7 @@ RabbitMQ.AMQP.Client.IConsumerBuilder.IJmsOptions.ConsumerTimeout(System.TimeSpa
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
-RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.OnDeliveryRelease(RabbitMQ.AMQP.Client.OnDeliveryRelease! onDeliveryRelease) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
+RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.OnDeliveryRelease(RabbitMQ.AMQP.Client.DeliveryReleaseHandler! deliveryReleaseHandler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions.SingleActiveConsumerStateChanged(RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler? handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions
 RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions.AbsoluteExpiryTime(System.DateTime absoluteExpiryTime) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IStreamFilterOptions!
@@ -633,7 +635,7 @@ RabbitMQ.AMQP.Client.Impl.JmsOptions.ConsumerTimeout(System.TimeSpan timeout) ->
 RabbitMQ.AMQP.Client.Impl.QuorumOptions
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.Builder() -> RabbitMQ.AMQP.Client.IConsumerBuilder!
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.ConsumerTimeout(System.TimeSpan timeout) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
-RabbitMQ.AMQP.Client.Impl.QuorumOptions.OnDeliveryRelease(RabbitMQ.AMQP.Client.OnDeliveryRelease! onDeliveryRelease) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
+RabbitMQ.AMQP.Client.Impl.QuorumOptions.OnDeliveryRelease(RabbitMQ.AMQP.Client.DeliveryReleaseHandler! deliveryReleaseHandler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.Impl.QuorumOptions.SingleActiveConsumerStateChanged(RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler? handler) -> RabbitMQ.AMQP.Client.IConsumerBuilder.IQuorumOptions!
 RabbitMQ.AMQP.Client.Impl.RequesterAddressBuilder
 RabbitMQ.AMQP.Client.Impl.RequesterAddressBuilder.Requester() -> RabbitMQ.AMQP.Client.IRequesterBuilder!
@@ -796,7 +798,6 @@ RabbitMQ.AMQP.Client.LeaderLocatorStrategy.Balanced = 1 -> RabbitMQ.AMQP.Client.
 RabbitMQ.AMQP.Client.LeaderLocatorStrategy.ClientLocal = 0 -> RabbitMQ.AMQP.Client.LeaderLocatorStrategy
 RabbitMQ.AMQP.Client.LifeCycleCallBack
 RabbitMQ.AMQP.Client.MessageHandler
-RabbitMQ.AMQP.Client.OnDeliveryRelease
 RabbitMQ.AMQP.Client.SingleActiveConsumerStateHandler
 RabbitMQ.AMQP.Client.MetricsReporter
 RabbitMQ.AMQP.Client.MetricsReporter.ConnectionClosed() -> void

--- a/RabbitMQ.AMQP.Client/Utils.cs
+++ b/RabbitMQ.AMQP.Client/Utils.cs
@@ -180,7 +180,8 @@ namespace RabbitMQ.AMQP.Client
         }
 
         internal static Attach CreateAttach(string? address,
-            DeliveryMode deliveryMode, Guid linkId, Map? sourceFilter = null, bool preSettled = false)
+            DeliveryMode deliveryMode, Guid linkId, Map? sourceFilter = null, bool preSettled = false,
+            Fields? attachProperties = null)
         {
             SenderSettleMode sndSettleMode;
             ReceiverSettleMode rcvSettleMode;
@@ -204,6 +205,7 @@ namespace RabbitMQ.AMQP.Client
                 SndSettleMode = sndSettleMode,
                 RcvSettleMode = rcvSettleMode,
                 LinkName = linkId.ToString(),
+                Properties = attachProperties,
                 // Role = true,
                 Target = new Target()
                 {
@@ -219,7 +221,7 @@ namespace RabbitMQ.AMQP.Client
                     Timeout = 0,
                     Dynamic = false,
                     Durable = 0,
-                    FilterSet = sourceFilter
+                    FilterSet = sourceFilter,
                 }
             };
             return attach;

--- a/Tests/Consumer/TimeoutDeliveryContextTests.cs
+++ b/Tests/Consumer/TimeoutDeliveryContextTests.cs
@@ -1,0 +1,61 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System;
+using System.Collections.Generic;
+using RabbitMQ.AMQP.Client.Impl;
+using Xunit;
+
+namespace Tests.Consumer;
+
+/// <summary>
+/// Unit tests for <see cref="TimeoutDeliveryContext"/>.
+/// These tests do not require a running broker.
+/// </summary>
+public class TimeoutDeliveryContextTests
+{
+    /// <summary>
+    /// Discard/Requeue/Batch all throw before touching the link or message,
+    /// so null is safe for the constructor arguments in those tests.
+    /// </summary>
+    private static TimeoutDeliveryContext CreateContext() =>
+        new(null!, null!, new UnsettledMessageCounter(), metricsReporter: null);
+
+    [Fact]
+    public void Discard_throws_InvalidOperationException()
+    {
+        TimeoutDeliveryContext ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(() => ctx.Discard());
+    }
+
+    [Fact]
+    public void Discard_with_annotations_throws_InvalidOperationException()
+    {
+        TimeoutDeliveryContext ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => ctx.Discard(new Dictionary<string, object> { ["x-reason"] = "bad" }));
+    }
+
+    [Fact]
+    public void Requeue_throws_InvalidOperationException()
+    {
+        TimeoutDeliveryContext ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(() => ctx.Requeue());
+    }
+
+    [Fact]
+    public void Requeue_with_annotations_throws_InvalidOperationException()
+    {
+        TimeoutDeliveryContext ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(
+            () => ctx.Requeue(new Dictionary<string, object> { ["x-reason"] = "retry" }));
+    }
+
+    [Fact]
+    public void Batch_throws_InvalidOperationException()
+    {
+        TimeoutDeliveryContext ctx = CreateContext();
+        Assert.Throws<InvalidOperationException>(() => ctx.Batch());
+    }
+}

--- a/Tests/Management/ManagementTests.cs
+++ b/Tests/Management/ManagementTests.cs
@@ -186,6 +186,7 @@ public class ManagementTests(ITestOutputHelper testOutputHelper) : IntegrationTe
             .DeadLetterStrategy(QuorumQueueDeadLetterStrategy.AtLeastOnce)
             .QuorumInitialGroupSize(3)
             .QuorumTargetGroupSize(5)
+            .ConsumerTimeout(TimeSpan.FromMinutes(30))
             .Queue()
             .DeclareAsync();
 
@@ -195,6 +196,7 @@ public class ManagementTests(ITestOutputHelper testOutputHelper) : IntegrationTe
         Assert.Equal(3, queueInfo.Arguments()["x-quorum-initial-group-size"]);
         Assert.Equal(5, queueInfo.Arguments()["x-quorum-target-group-size"]);
         Assert.Equal("client-local", queueInfo.Arguments()["x-queue-leader-locator"]);
+        Assert.Equal(1_800_000L, queueInfo.Arguments()["x-consumer-timeout"]);
         // NB: DisposeAsync will delete the queue with name _queueName
     }
 
@@ -309,6 +311,16 @@ public class ManagementTests(ITestOutputHelper testOutputHelper) : IntegrationTe
         await Assert.ThrowsAsync<ArgumentException>(() =>
             _management.Queue().Name(_queueName).Quorum()
                 .DeliveryLimit(-1)
+                .Queue().DeclareAsync());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _management.Queue().Name(_queueName).Quorum()
+                .ConsumerTimeout(TimeSpan.Zero)
+                .Queue().DeclareAsync());
+
+        await Assert.ThrowsAsync<ArgumentException>(() =>
+            _management.Queue().Name(_queueName).Jms()
+                .ConsumerTimeout(TimeSpan.FromSeconds(-1))
                 .Queue().DeclareAsync());
     }
 

--- a/Tests/Management/QueueConsumerTimeoutTests.cs
+++ b/Tests/Management/QueueConsumerTimeoutTests.cs
@@ -1,0 +1,162 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using RabbitMQ.AMQP.Client;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Tests.Management;
+
+public class QueueConsumerTimeoutTests(ITestOutputHelper testOutputHelper) : IntegrationTest(testOutputHelper)
+{
+    [Fact]
+    public void Quorum_builder_sets_x_consumer_timeout_and_quorum_queue_type_in_queue_arguments()
+    {
+        Assert.NotNull(_management);
+
+        IQueueSpecification spec = _management.Queue()
+            .Name(_queueName)
+            .Quorum()
+            .ConsumerTimeout(TimeSpan.FromSeconds(90))
+            .Queue();
+
+        Dictionary<object, object> args = spec.QueueArguments;
+        Assert.Equal("quorum", args["x-queue-type"]);
+        Assert.Equal(90_000L, args["x-consumer-timeout"]);
+    }
+
+    [Fact]
+    public void Jms_builder_sets_x_consumer_timeout_and_jms_queue_type_in_queue_arguments()
+    {
+        Assert.NotNull(_management);
+
+        IQueueSpecification spec = _management.Queue()
+            .Name(_queueName)
+            .Jms()
+            .ConsumerTimeout(TimeSpan.FromMinutes(2))
+            .Queue();
+
+        Dictionary<object, object> args = spec.QueueArguments;
+        Assert.Equal("jms", args["x-queue-type"]);
+        Assert.Equal(120_000L, args["x-consumer-timeout"]);
+    }
+
+    [Fact]
+    public void Quorum_consumer_timeout_can_be_combined_with_other_quorum_arguments()
+    {
+        Assert.NotNull(_management);
+
+        IQueueSpecification spec = _management.Queue()
+            .Name(_queueName)
+            .Quorum()
+            .DeliveryLimit(7)
+            .ConsumerTimeout(TimeSpan.FromMilliseconds(500))
+            .QuorumTargetGroupSize(4)
+            .Queue();
+
+        Dictionary<object, object> args = spec.QueueArguments;
+        Assert.Equal("quorum", args["x-queue-type"]);
+        Assert.Equal(7, args["x-max-delivery-limit"]);
+        Assert.Equal(4, args["x-quorum-target-group-size"]);
+        Assert.Equal(500L, args["x-consumer-timeout"]);
+    }
+
+    [Fact]
+    public async Task Declare_quorum_queue_round_trips_x_consumer_timeout_from_broker()
+    {
+        Assert.NotNull(_management);
+
+        IQueueSpecification spec = _management.Queue()
+            .Name(_queueName)
+            .Quorum()
+            .ConsumerTimeout(TimeSpan.FromMinutes(15))
+            .Queue();
+
+        IQueueInfo declared = await spec.DeclareAsync();
+        Assert.Equal(900_000L, declared.Arguments()["x-consumer-timeout"]);
+
+        IQueueInfo fetched = await _management.GetQueueInfoAsync(spec);
+        Assert.Equal(900_000L, fetched.Arguments()["x-consumer-timeout"]);
+    }
+
+    [SkippableFact]
+    public async Task Declare_jms_queue_round_trips_x_consumer_timeout_when_broker_supports_jms()
+    {
+        Assert.NotNull(_management);
+
+        IQueueSpecification spec = _management.Queue()
+            .Name(_queueName)
+            .Jms()
+            .ConsumerTimeout(TimeSpan.FromMinutes(10))
+            .Queue();
+
+        try
+        {
+            IQueueInfo declared = await spec.DeclareAsync();
+            Assert.Equal(600_000L, declared.Arguments()["x-consumer-timeout"]);
+            Assert.Equal("jms", declared.Arguments()["x-queue-type"]);
+            Assert.Equal(QueueType.JMS, declared.Type());
+
+            IQueueInfo fetched = await _management.GetQueueInfoAsync(spec);
+            Assert.Equal(600_000L, fetched.Arguments()["x-consumer-timeout"]);
+        }
+        catch (PreconditionFailedException)
+        {
+            Skip.If(true, "Broker does not support x-queue-type jms (declare returned 409).");
+        }
+    }
+
+    [Fact]
+    public async Task Consumer_with_quorum_attach_consumer_timeout_starts()
+    {
+        Assert.NotNull(_connection);
+        Assert.NotNull(_management);
+
+        IQueueSpecification queueSpec = _management.Queue()
+            .Name(_queueName)
+            .Quorum()
+            .ConsumerTimeout(TimeSpan.FromMinutes(10))
+            .Queue();
+
+        await queueSpec.DeclareAsync();
+
+        IConsumer consumer = await _connection.ConsumerBuilder()
+            .Queue(queueSpec)
+            .Quorum()
+            .ConsumerTimeout(TimeSpan.FromMinutes(2))
+            .Builder()
+            .MessageHandler((context, message) =>
+            {
+                context.Accept();
+                return Task.CompletedTask;
+            })
+            .BuildAndStartAsync();
+
+        await consumer.CloseAsync();
+        consumer.Dispose();
+    }
+
+    [Fact]
+    public async Task Consumer_builder_quorum_consumer_timeout_throws_with_direct_reply_to()
+    {
+        Assert.NotNull(_connection);
+        Assert.NotNull(_management);
+
+        IQueueSpecification queueSpec = _management.Queue().Name(_queueName).Quorum().Queue();
+        await queueSpec.DeclareAsync();
+
+        NotSupportedException ex = await Assert.ThrowsAsync<NotSupportedException>(async () =>
+            await _connection.ConsumerBuilder()
+                .Queue(queueSpec).Quorum()
+                .ConsumerTimeout(TimeSpan.FromMinutes(1)).Builder()
+                .SettleStrategy(ConsumerSettleStrategy.DirectReplyTo)
+                .MessageHandler((_, _) => Task.CompletedTask)
+                .BuildAndStartAsync());
+
+        Assert.Contains("Consumer timeout is not supported", ex.Message, StringComparison.Ordinal);
+    }
+}

--- a/Tests/Management/QueueConsumerTimeoutTests.cs
+++ b/Tests/Management/QueueConsumerTimeoutTests.cs
@@ -6,6 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using RabbitMQ.AMQP.Client;
+using RabbitMQ.AMQP.Client.Impl;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -158,5 +159,154 @@ public class QueueConsumerTimeoutTests(ITestOutputHelper testOutputHelper) : Int
                 .BuildAndStartAsync());
 
         Assert.Contains("Consumer timeout is not supported", ex.Message, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Verifies that the OnDeliveryRelease callback is invoked when the broker releases a
+    /// delivery because the consumer did not settle it within its configured timeout, and
+    /// that calling Accept() inside the callback successfully unlocks the consumer.
+    /// </summary>
+    [Fact]
+    public async Task OnDeliveryRelease_callback_is_invoked_when_broker_releases_timed_out_delivery()
+    {
+        Assert.NotNull(_connection);
+        Assert.NotNull(_management);
+
+        TimeSpan consumerTimeout = TimeSpan.FromSeconds(3);
+
+        IQueueSpecification queueSpec = _management.Queue()
+            .Name(_queueName)
+            .Quorum()
+            .Queue();
+
+        await queueSpec.DeclareAsync();
+
+        TaskCompletionSource<IMessage> releaseTcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        IConsumer consumer = await _connection.ConsumerBuilder()
+            .Queue(queueSpec)
+            .Quorum()
+            .ConsumerTimeout(consumerTimeout)
+            .OnDeliveryRelease((context, message) =>
+            {
+                context.Accept();
+                releaseTcs.TrySetResult(message);
+                return Task.CompletedTask;
+            })
+            .Builder()
+            .MessageHandler(async (context, message) =>
+            {
+                // Hold the message past the consumer timeout so the broker releases it.
+                await Task.Delay(TimeSpan.FromSeconds(5));
+                try
+                {
+                    context.Accept();
+                }
+                catch
+                {
+                    // Expected: the broker has already released the delivery.
+                }
+            })
+            .BuildAndStartAsync();
+
+        IPublisher publisher = await _connection.PublisherBuilder().Queue(queueSpec).BuildAsync();
+        try
+        {
+            await publisher.PublishAsync(new AmqpMessage("timeout-message"));
+
+            // The broker should release the delivery after ~3 s; allow generous headroom.
+            IMessage releasedMessage =
+                await releaseTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
+
+            Assert.Equal("timeout-message", releasedMessage.BodyAsString());
+        }
+        finally
+        {
+            await publisher.CloseAsync();
+            publisher.Dispose();
+            await consumer.CloseAsync();
+            consumer.Dispose();
+        }
+    }
+
+    /// <summary>
+    /// Verifies that after OnDeliveryRelease fires and Accept() is called (unlocking the consumer),
+    /// the consumer can receive and process subsequent messages normally.
+    /// </summary>
+    [Fact]
+    public async Task Consumer_continues_receiving_messages_after_OnDeliveryRelease_accept()
+    {
+        Assert.NotNull(_connection);
+        Assert.NotNull(_management);
+
+        TimeSpan consumerTimeout = TimeSpan.FromSeconds(3);
+
+        IQueueSpecification queueSpec = _management.Queue()
+            .Name(_queueName)
+            .Quorum()
+            .Queue();
+
+        await queueSpec.DeclareAsync();
+
+        TaskCompletionSource<bool> releaseTcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+        TaskCompletionSource<IMessage> messageTcs =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        bool timeoutTriggered = false;
+
+        IConsumer consumer = await _connection.ConsumerBuilder()
+            .Queue(queueSpec)
+            .Quorum()
+            .ConsumerTimeout(consumerTimeout)
+            .OnDeliveryRelease((context, _) =>
+            {
+                context.Accept();
+                timeoutTriggered = true;
+                releaseTcs.TrySetResult(true);
+                return Task.CompletedTask;
+            })
+            .Builder()
+            .MessageHandler(async (context, message) =>
+            {
+                if (!timeoutTriggered)
+                {
+                    // First message: delay past timeout to trigger OnDeliveryRelease.
+                    await Task.Delay(TimeSpan.FromSeconds(5));
+                    try { context.Accept(); } catch { }
+                }
+                else
+                {
+                    // Second message: accept immediately after the consumer is unlocked.
+                    context.Accept();
+                    messageTcs.TrySetResult(message);
+                }
+            })
+            .BuildAndStartAsync();
+
+        IPublisher publisher = await _connection.PublisherBuilder().Queue(queueSpec).BuildAsync();
+        try
+        {
+            await publisher.PublishAsync(new AmqpMessage("first-message"));
+
+            // Wait for the timeout/release callback.
+            await releaseTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            Assert.True(timeoutTriggered);
+
+            // Publish a second message; the consumer should now be unlocked.
+            await publisher.PublishAsync(new AmqpMessage("second-message"));
+
+            IMessage m =
+                await messageTcs.Task.WaitAsync(TimeSpan.FromSeconds(15));
+            Assert.Equal("first-message", m.BodyAsString());
+        }
+        finally
+        {
+            await publisher.CloseAsync();
+            publisher.Dispose();
+            await consumer.CloseAsync();
+            consumer.Dispose();
+        }
     }
 }

--- a/docs/Examples/ConsumerTimeout/ConsumerTimeout.csproj
+++ b/docs/Examples/ConsumerTimeout/ConsumerTimeout.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <NoWarn>$(NoWarn);CA2007</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../../RabbitMQ.AMQP.Client/RabbitMQ.AMQP.Client.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/docs/Examples/ConsumerTimeout/Program.cs
+++ b/docs/Examples/ConsumerTimeout/Program.cs
@@ -1,0 +1,111 @@
+// This source code is dual-licensed under the Apache License, version 2.0,
+// and the Mozilla Public License, version 2.0.
+// Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+
+// RabbitMQ AMQP 1.0 client: https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client
+// RabbitMQ AMQP 1.0 .NET Example - Quorum queue consumer timeout (x-consumer-timeout)
+// Full path example: https://github.com/rabbitmq/rabbitmq-amqp-dotnet-client/tree/main/docs/Examples/ConsumerTimeout
+//
+// Consumer timeouts limit how long a consumer may hold a message without settling it (accept / reject / release).
+// For quorum queues you can set:
+// - Queue argument x-consumer-timeout (via IQueueSpecification.Quorum().ConsumerTimeout(...))
+// - Per-consumer attach property rabbitmq:consumer-timeout (via IConsumerBuilder.Quorum().ConsumerTimeout(...).Builder())
+// See: https://www.rabbitmq.com/docs/consumers#consumer-timeout
+//
+// This sample declares a quorum queue with a queue-level timeout, attaches a consumer with its own consumer-level
+// timeout (highest precedence when both are set), and settles messages immediately so the timeout is not hit.
+
+using System.Diagnostics;
+using RabbitMQ.AMQP.Client;
+using RabbitMQ.AMQP.Client.Impl;
+using Trace = Amqp.Trace;
+using TraceLevel = Amqp.TraceLevel;
+
+Trace.TraceLevel = TraceLevel.Information;
+
+ConsoleTraceListener consoleListener = new();
+Trace.TraceListener = (l, f, a) =>
+    consoleListener.WriteLine($"[{DateTime.Now}] [{l}] - {f}");
+
+Trace.WriteLine(TraceLevel.Information, "Starting ConsumerTimeout (quorum queue) example...");
+const string containerId = "consumer-timeout-example-connection";
+
+IEnvironment environment = AmqpEnvironment.Create(
+    ConnectionSettingsBuilder.Create().ContainerId(containerId).Build());
+
+IConnection connection = await environment.CreateConnectionAsync();
+Trace.WriteLine(TraceLevel.Information, $"Connected to the broker {connection} successfully");
+
+IManagement management = connection.Management();
+const string queueName = "q_amqp10-consumer-timeout-example";
+
+// TimeSpan queueConsumerTimeout = TimeSpan.FromMinutes(3);
+TimeSpan attachConsumerTimeout = TimeSpan.FromSeconds(3);
+
+IQueueSpecification queueSpec = management.Queue(queueName)
+    .Quorum()
+    // .ConsumerTimeout(queueConsumerTimeout)
+    .Queue();
+
+IQueueInfo queueInfo = await queueSpec.DeclareAsync();
+// Trace.WriteLine(TraceLevel.Information,
+//     $"Queue declared with x-consumer-timeout={queueInfo.Arguments()["x-consumer-timeout"]} ms (queue default).");
+
+IPublisher publisher = await connection.PublisherBuilder().Queue(queueSpec).BuildAsync();
+
+IConsumer consumer = await connection.ConsumerBuilder()
+    .Queue(queueSpec)
+    .Quorum()
+    .ConsumerTimeout(attachConsumerTimeout)
+    .Builder()
+
+    .MessageHandler(async (context, message) =>
+    {
+        Trace.WriteLine(TraceLevel.Information,
+            $"[Consumer] Message: {message.BodyAsString()} received; settling within consumer timeout");
+        await Task.Delay(TimeSpan.FromSeconds(4));
+        Trace.WriteLine(TraceLevel.Information,
+            $"[Consumer] Message: {message.BodyAsString()} after delay");
+        context.Accept();
+    })
+    .BuildAndStartAsync();
+
+Trace.WriteLine(TraceLevel.Information,
+    $"Consumer attached with rabbitmq:consumer-timeout={(uint)attachConsumerTimeout.TotalMilliseconds} ms (per-consumer).");
+
+const int total = 1;
+for (int i = 0; i < total; i++)
+{
+    var message = new AmqpMessage($"consumer-timeout-demo_{i}");
+    PublishResult pr = await publisher.PublishAsync(message);
+    switch (pr.Outcome.State)
+    {
+        case OutcomeState.Accepted:
+            Trace.WriteLine(TraceLevel.Information, $"[Publisher] Message confirmed: {message.BodyAsString()}");
+            break;
+        case OutcomeState.Released:
+            Trace.WriteLine(TraceLevel.Information, $"[Publisher] Message released: {message.BodyAsString()}");
+            break;
+        case OutcomeState.Rejected:
+            Trace.WriteLine(TraceLevel.Error,
+                $"[Publisher] Message rejected: {message.BodyAsString()} error={pr.Outcome.Error}");
+            break;
+        default:
+            throw new ArgumentOutOfRangeException();
+    }
+}
+
+Console.WriteLine("Press any key to close publisher, consumer, delete the queue, and exit.");
+Console.ReadKey();
+
+await publisher.CloseAsync();
+publisher.Dispose();
+
+await consumer.CloseAsync();
+consumer.Dispose();
+
+await queueSpec.DeleteAsync();
+
+await environment.CloseAsync();
+
+Trace.WriteLine(TraceLevel.Information, "Example closed successfully");

--- a/docs/Examples/ConsumerTimeout/Program.cs
+++ b/docs/Examples/ConsumerTimeout/Program.cs
@@ -10,7 +10,7 @@
 // For quorum queues you can set:
 // - Queue argument x-consumer-timeout (via IQueueSpecification.Quorum().ConsumerTimeout(...))
 // - Per-consumer attach property rabbitmq:consumer-timeout (via IConsumerBuilder.Quorum().ConsumerTimeout(...).Builder())
-// See: https://www.rabbitmq.com/docs/consumers#consumer-timeout
+// See: https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#consumer-timeouts
 //
 // This sample declares a quorum queue with a queue-level timeout, attaches a consumer with its own consumer-level
 // timeout (highest precedence when both are set), and settles messages immediately so the timeout is not hit.
@@ -58,6 +58,9 @@ int secondsToWait = 4;
 IConsumer consumer = await connection.ConsumerBuilder()
     .Queue(queueSpec)
     .Quorum()
+    // There are different ways to configure the consumer timeout, 
+    // see https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#consumer-timeouts
+    
     .ConsumerTimeout(attachConsumerTimeout)
     .OnDeliveryRelease((context, message) =>
     {

--- a/docs/Examples/ConsumerTimeout/Program.cs
+++ b/docs/Examples/ConsumerTimeout/Program.cs
@@ -18,6 +18,7 @@
 using System.Diagnostics;
 using RabbitMQ.AMQP.Client;
 using RabbitMQ.AMQP.Client.Impl;
+using IConnection = RabbitMQ.AMQP.Client.IConnection;
 using Trace = Amqp.Trace;
 using TraceLevel = Amqp.TraceLevel;
 
@@ -33,13 +34,15 @@ const string containerId = "consumer-timeout-example-connection";
 IEnvironment environment = AmqpEnvironment.Create(
     ConnectionSettingsBuilder.Create().ContainerId(containerId).Build());
 
-IConnection connection = await environment.CreateConnectionAsync();
+IConnection connection = await environment
+    .CreateConnectionAsync(ConnectionSettingsBuilder.Create().Build())
+    .ConfigureAwait(false);
 Trace.WriteLine(TraceLevel.Information, $"Connected to the broker {connection} successfully");
 
 IManagement management = connection.Management();
 const string queueName = "q_amqp10-consumer-timeout-example";
 
-// TimeSpan queueConsumerTimeout = TimeSpan.FromMinutes(3);
+//TimeSpan queueConsumerTimeout = TimeSpan.FromSeconds(3);
 TimeSpan attachConsumerTimeout = TimeSpan.FromSeconds(3);
 
 IQueueSpecification queueSpec = management.Queue(queueName)
@@ -47,26 +50,45 @@ IQueueSpecification queueSpec = management.Queue(queueName)
     // .ConsumerTimeout(queueConsumerTimeout)
     .Queue();
 
-IQueueInfo queueInfo = await queueSpec.DeclareAsync();
-// Trace.WriteLine(TraceLevel.Information,
-//     $"Queue declared with x-consumer-timeout={queueInfo.Arguments()["x-consumer-timeout"]} ms (queue default).");
+await queueSpec.DeclareAsync();
 
 IPublisher publisher = await connection.PublisherBuilder().Queue(queueSpec).BuildAsync();
 
+int secondsToWait = 4;
 IConsumer consumer = await connection.ConsumerBuilder()
     .Queue(queueSpec)
     .Quorum()
     .ConsumerTimeout(attachConsumerTimeout)
-    .Builder()
+    .OnDeliveryRelease((context, message) =>
+    {
+        Trace.WriteLine(TraceLevel.Information,
+            $"[Consumer] Message: {message.BodyAsString()} released by consumer. Going to unlock the consumer");
 
+        // Here we unlock the consumer from the consumer timeout state.
+        // In this example, only one time has to raise the timeout, then we reset the secondsToWait to 0 to avoid
+        // hitting the timeout for subsequent messages.
+        context.Accept();
+        return Task.CompletedTask;
+    }).Builder()
     .MessageHandler(async (context, message) =>
     {
         Trace.WriteLine(TraceLevel.Information,
-            $"[Consumer] Message: {message.BodyAsString()} received; settling within consumer timeout");
-        await Task.Delay(TimeSpan.FromSeconds(4));
-        Trace.WriteLine(TraceLevel.Information,
-            $"[Consumer] Message: {message.BodyAsString()} after delay");
-        context.Accept();
+            $"[Consumer] Message: {message.BodyAsString()} received; going to wait for {secondsToWait} seconds before accepting the message to trigger the consumer timeout");
+        await Task.Delay(TimeSpan.FromSeconds(secondsToWait));
+        secondsToWait =
+            0; // only delay the first message to trigger the timeout, then reset to 0 for subsequent messages
+
+        // In the first iteration the context.Accept() is ignored since id requeued due to timeout,
+        // but in the second iteration it works as expected since the timeout is not hit.
+        try
+        {
+            context.Accept();
+            Trace.WriteLine(TraceLevel.Information, $"[Consumer] Message: {message.BodyAsString()} accepted");
+        }
+        catch (Exception e)
+        {
+            Trace.WriteLine(TraceLevel.Error, $"[Consumer] Failed to accept message: {e.Message}");
+        }
     })
     .BuildAndStartAsync();
 

--- a/docs/Examples/ConsumerTimeout/Program.cs
+++ b/docs/Examples/ConsumerTimeout/Program.cs
@@ -60,7 +60,7 @@ IConsumer consumer = await connection.ConsumerBuilder()
     .Quorum()
     // There are different ways to configure the consumer timeout, 
     // see https://www.rabbitmq.com/blog/2026/04/23/rabbitmq-4.3-release#consumer-timeouts
-    
+
     .ConsumerTimeout(attachConsumerTimeout)
     .OnDeliveryRelease((context, message) =>
     {

--- a/docs/Examples/README.md
+++ b/docs/Examples/README.md
@@ -9,6 +9,7 @@ This directory contains examples of how to use the RabbitMQ AMQP 1.0 .NET client
 - OpenTelemetry Integration [here](./OpenTelemetryIntegration/)
 - OAuth2 Example [here](./OAuth2)
 - Batch Disposition [here](./BatchDispositions)
+- Quorum queue consumer timeout (`x-consumer-timeout`) [here](./ConsumerTimeout/)
 - Stream Filter [here](./StreamFilter)
 - AMQP 1.0 over WebSockets [here](./WebSockets) 
 - Affinity node [here](./Affinity/)

--- a/docs/Examples/README.md
+++ b/docs/Examples/README.md
@@ -4,7 +4,7 @@ This directory contains examples of how to use the RabbitMQ AMQP 1.0 .NET client
 
 - Getting Started with the Client [here](./GettingStarted/)
 - RPC Server and Client [here](./Rpc/)
-- How to write a reliable client [here](./HAClient/)
+- How to write a reliable client [here](./ReliableClient/)
 - Performance Test [here](./PerformanceTest/). You can tune some parameters in the `Program.cs` file.
 - OpenTelemetry Integration [here](./OpenTelemetryIntegration/)
 - OAuth2 Example [here](./OAuth2)
@@ -14,8 +14,8 @@ This directory contains examples of how to use the RabbitMQ AMQP 1.0 .NET client
 - AMQP 1.0 over WebSockets [here](./WebSockets) 
 - Affinity node [here](./Affinity/)
 - Single Active Consumer [here](./SingleActiveConsumer/)
-- PreSettled Consumer [here](./PreSettled/)
-- Stream group id filtering [here](./GroupIdFiltering/) 
+- PreSettled Consumer [here](./Presettled/)
+- Stream group id filtering [here](./GroupIdStreamFiltering/) 
 - Quorum queue single active consumer notifications [here](./QQSingleActiveNotification/)
 - Rejection reason (rejected-by queue name + reason, requires RabbitMQ 4.3+) [here](./RejectionReason/)
-- Quorum queue delayed retry with linear back-off (requires RabbitMQ 4.3+) [here](./QQDelayedRetry/)
+- Quorum queue delayed retry (requires RabbitMQ 4.3+) [here](./QQDelayedRetry/)

--- a/rabbitmq-amqp-dotnet-client.sln
+++ b/rabbitmq-amqp-dotnet-client.sln
@@ -55,6 +55,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "RejectionReason", "docs\Exa
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QQDelayedRetry", "docs\Examples\QQDelayedRetry\QQDelayedRetry.csproj", "{2A9A963B-0C00-4B99-AD0B-B187793CB382}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsumerTimeout", "docs\Examples\ConsumerTimeout\ConsumerTimeout.csproj", "{C9B7D8E1-4A5F-48C3-9E2B-6D1F0A8E4C7B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -133,6 +135,10 @@ Global
 		{2A9A963B-0C00-4B99-AD0B-B187793CB382}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2A9A963B-0C00-4B99-AD0B-B187793CB382}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2A9A963B-0C00-4B99-AD0B-B187793CB382}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C9B7D8E1-4A5F-48C3-9E2B-6D1F0A8E4C7B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C9B7D8E1-4A5F-48C3-9E2B-6D1F0A8E4C7B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C9B7D8E1-4A5F-48C3-9E2B-6D1F0A8E4C7B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C9B7D8E1-4A5F-48C3-9E2B-6D1F0A8E4C7B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,5 +160,6 @@ Global
 		{F4C8A2E1-9D3B-4C7A-8F2E-1B6D5A9C3E7F} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 		{A1B2C3D4-E5F6-7A8B-9C0D-E1F2A3B4C5D6} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 		{2A9A963B-0C00-4B99-AD0B-B187793CB382} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
+		{C9B7D8E1-4A5F-48C3-9E2B-6D1F0A8E4C7B} = {9154A0FB-7B2B-413C-A7F5-11ED2E37E93C}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION

Add support for handling AMQP delivery releases triggered by quorum
queue consumer timeouts (x-consumer-timeout). When the broker releases
a timed-out delivery, the new OnDeliveryRelease callback on
IConsumerBuilder.IQuorumOptions is invoked with a restricted context
(TimedOutDeliveryContext) that only permits Accept() to unlock the
consumer; Discard and Requeue are rejected with InvalidOperationException.

Introduce ConnectionHandler to route DeliveryStateChanged events from
amqpnetlite to the correct AmqpConsumer by receiver link name, and
AmqpConnectionHandler to intercept ConnectionLocalOpen /
ConnectionRemoteOpen frames (injecting connection_name, extracting
broker capabilities) while delegating other events to ConnectionHandler.
AmqpConnection exposes RegisterConsumerDeliveryHandler /
UnregisterConsumerDeliveryHandler so consumers can self-register.

Refactor AmqpConnection to configure the AMQP OPEN frame via
ConnectionFactory.AMQP properties (HostName, ContainerId, MaxFrameSize)
instead of constructing an explicit Open object, which allows the
handler chain to be wired in cleanly.

Also add UNLOCK to ConsumeDispositionValue in IMetricsReporter and
update the ConsumerTimeout example to demonstrate the new API.