### PR TITLE
Handle management errors.

### DIFF
--- a/RabbitMQ.AMQP.Client/Impl/AmqpManagement.cs
+++ b/RabbitMQ.AMQP.Client/Impl/AmqpManagement.cs
@@ -158,8 +158,7 @@ namespace RabbitMQ.AMQP.Client.Impl
             await EnsureReceiverLinkAsync()
                 .ConfigureAwait(false);
 
-            // TODO do something with this task?
-            _ = Task.Run(ProcessResponses);
+            BeginProcessingResponses();
 
             _managementSession.AddClosedCallback(OnManagementSessionClosed);
 
@@ -435,48 +434,56 @@ namespace RabbitMQ.AMQP.Client.Impl
             _managementSessionClosedTcs.TrySetResult(true);
         }
 
-        private async Task ProcessResponses()
+        protected void BeginProcessingResponses()
         {
-            try
-            {
-                while (_managementSession?.IsClosed == false &&
-                       _amqpManagementParameters.IsNativeConnectionClosed == false)
+            _ = Task.Run(ProcessResponsesAsync).ContinueWith(
+                t =>
                 {
-                    if (_receiverLink == null)
+                    if (State == State.Closed || State == State.Closing)
                     {
+                        return;
+                    }
+
+                    Exception? inner = t.Exception?.InnerException;
+                    Trace.WriteLine(TraceLevel.Error,
+                        $"{ToString()} management session receiver faulted: {inner}");
+                    OnNewStatus(State.Closed,
+                        new Error("management.session.faulted", inner?.Message ?? "unexpected error"));
+                },
+                System.Threading.CancellationToken.None,
+                TaskContinuationOptions.OnlyOnFaulted,
+                TaskScheduler.Default);
+        }
+
+        protected virtual async Task ProcessResponsesAsync()
+        {
+            while (_managementSession?.IsClosed == false &&
+                   _amqpManagementParameters.IsNativeConnectionClosed == false)
+            {
+                if (_receiverLink == null)
+                {
+                    continue;
+                }
+
+                TimeSpan timeout = TimeSpan.FromSeconds(59);
+                using (Message msg = await _receiverLink.ReceiveAsync(timeout).ConfigureAwait(false))
+                {
+                    if (msg == null)
+                    {
+                        // this is not a problem, it is just a timeout.
+                        // the timeout is set to 60 seconds.
+                        // For the moment I'd trace it at some point we can remove it
+                        Trace.WriteLine(TraceLevel.Verbose,
+                            $"{ToString()} - Timeout {timeout.Seconds} s.. waiting for message.");
                         continue;
                     }
 
-                    TimeSpan timeout = TimeSpan.FromSeconds(59);
-                    using (Message msg = await _receiverLink.ReceiveAsync(timeout).ConfigureAwait(false))
-                    {
-                        if (msg == null)
-                        {
-                            // this is not a problem, it is just a timeout. 
-                            // the timeout is set to 60 seconds. 
-                            // For the moment I'd trace it at some point we can remove it
-                            Trace.WriteLine(TraceLevel.Verbose,
-                                $"{ToString()} - Timeout {timeout.Seconds} s.. waiting for message.");
-                            continue;
-                        }
-
-                        _receiverLink.Accept(msg);
-                        HandleResponseMessage(msg);
-                    }
-                }
-            }
-            catch (Exception e)
-            {
-                // TODO this is a serious situation that should be thrown
-                // up to the client application
-                if (_receiverLink?.IsClosed == false)
-                {
-                    Trace.WriteLine(TraceLevel.Error,
-                        $"Receiver link error in management session {e}. Receiver link closed: {_receiverLink?.IsClosed}");
+                    _receiverLink.Accept(msg);
+                    HandleResponseMessage(msg);
                 }
             }
 
-            Trace.WriteLine(TraceLevel.Verbose, "ProcessResponses Task closed");
+            Trace.WriteLine(TraceLevel.Verbose, "ProcessResponsesAsync task closed");
         }
 
         private async Task EnsureReceiverLinkAsync()

--- a/Tests/Management/MockManagementTests.cs
+++ b/Tests/Management/MockManagementTests.cs
@@ -3,6 +3,7 @@
 // Copyright (c) 2017-2024 Broadcom. All Rights Reserved. The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
 
 using System;
+using System.Threading;
 using System.Threading.Tasks;
 using Amqp.Framing;
 using RabbitMQ.AMQP.Client;
@@ -118,6 +119,79 @@ public class MockManagementTests()
         await Assert.ThrowsAsync<AmqpNotOpenException>(async () =>
            await management.RequestAsync(new Message(), [200]));
         Assert.Equal(State.Closed, management.State);
+    }
+
+    // ---- ProcessResponsesAsync fault-propagation tests ----
+
+    public class TestAmqpManagementFaultingSession : AmqpManagement
+    {
+        public TestAmqpManagementFaultingSession() : base(new AmqpManagementParameters(null!))
+        {
+            State = State.Open;
+        }
+
+        protected override Task ProcessResponsesAsync()
+            => Task.FromException(new InvalidOperationException("simulated receiver link fault"));
+
+        public void StartProcessing() => BeginProcessingResponses();
+
+        internal protected override async Task InternalSendAsync(Message message, TimeSpan timeout)
+            => await Task.Delay(1);
+    }
+
+    public class TestAmqpManagementCleanSession : AmqpManagement
+    {
+        public TestAmqpManagementCleanSession() : base(new AmqpManagementParameters(null!))
+        {
+            State = State.Open;
+        }
+
+        protected override Task ProcessResponsesAsync() => Task.CompletedTask;
+
+        public void StartProcessing() => BeginProcessingResponses();
+
+        internal protected override async Task InternalSendAsync(Message message, TimeSpan timeout)
+            => await Task.Delay(1);
+    }
+
+    [Fact]
+    public async Task ProcessingSessionFault_TransitionsManagementToClosed()
+    {
+        var management = new TestAmqpManagementFaultingSession();
+        var stateChangeTcs = Utils.CreateTaskCompletionSource<State>();
+        management.ChangeState += (_, _, newState, _) => stateChangeTcs.TrySetResult(newState);
+
+        management.StartProcessing();
+
+        State arrived = await stateChangeTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.Equal(State.Closed, arrived);
+    }
+
+    [Fact]
+    public async Task ProcessingSessionFault_FiresChangeStateWithError()
+    {
+        var management = new TestAmqpManagementFaultingSession();
+        var errorTcs = Utils.CreateTaskCompletionSource<RabbitMQ.AMQP.Client.Error?>();
+        management.ChangeState += (_, _, _, error) => errorTcs.TrySetResult(error);
+
+        management.StartProcessing();
+
+        RabbitMQ.AMQP.Client.Error? error = await errorTcs.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        Assert.NotNull(error);
+    }
+
+    [Fact]
+    public async Task ProcessingSessionCleanExit_DoesNotChangeState()
+    {
+        var management = new TestAmqpManagementCleanSession();
+        bool stateChanged = false;
+        management.ChangeState += (_, _, _, _) => stateChanged = true;
+
+        management.StartProcessing();
+
+        await Task.Delay(200);
+        Assert.False(stateChanged);
+        Assert.Equal(State.Open, management.State);
     }
 
     [Theory]


### PR DESCRIPTION
ProcessResponses renamed to ProcessResponsesAsync and made protected virtual.

Try-catch removed; unexpected link exceptions now propagate naturally.

BeginProcessingResponses protected method replaces the Task.Run. Attaches a ContinueWith(OnlyOnFaulted) continuation that calls OnNewStatus(State.Closed, error) unless the session was already closing normally.

[ai-assisted=no]